### PR TITLE
fix: pin grafana-agent

### DIFF
--- a/bases/metrics/base/kustomization.yaml
+++ b/bases/metrics/base/kustomization.yaml
@@ -30,7 +30,3 @@ configMapGenerator:
       - PROM_SCRAPE_INTERVAL=15s
       - PROM_SCRAPE_TIMEOUT=10s
       - PROM_WAL_TRUNCATE_FREQUENCY=30m
-
-images:
-  - name: grafana/agent
-    newTag: 'v0.23.0'

--- a/bases/metrics/m/kustomization.yaml
+++ b/bases/metrics/m/kustomization.yaml
@@ -9,3 +9,7 @@ namePrefix: observe-
 
 commonLabels:
   observeinc.com/component: 'metrics'
+
+images:
+  - name: grafana/agent
+    newTag: 'v0.23.0'

--- a/bases/metrics/xl/kustomization.yaml
+++ b/bases/metrics/xl/kustomization.yaml
@@ -9,3 +9,7 @@ namePrefix: observe-
 
 commonLabels:
   observeinc.com/component: 'metrics'
+
+images:
+  - name: grafana/agent
+    newTag: 'v0.23.0'


### PR DESCRIPTION
We lifted the workload definition out of the metrics base, rendering the
previous version pin meaningless. This commit moves the version pin to
be alongside the deployment and daemonset definitions respectively.