### PR TITLE
build: add script to mirror manifests to S3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 CLUSTER_NAME?=chart-testing
+TAG?=$(shell git describe --tags)
 
 cluster:
 	@kind create cluster --name $(CLUSTER_NAME)
@@ -14,3 +15,6 @@ label_check:
 
 delete:
 	@scripts/test.sh -v delete
+
+s3:
+	@TAG=$(TAG) scripts/mirror stack

--- a/scripts/mirror
+++ b/scripts/mirror
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o pipefail
+
+DIR=${1}
+TAG="${TAG:=tag}"
+S3_ROOT="${S3_ROOT:=s3://observeinc/manifests}"
+
+DIE() { echo "${R}E! $*${r}" 1>&2; exit 1; }
+INFO() { echo "${B}I: $*${r}" 1>&2; }
+DEBUG() { test -z "$VERBOSE" || echo "D: $*" 1>&2; }
+
+
+STACKS=`find ${DIR} -name 'kustomization.yaml' -exec dirname {} ';'`
+for STACK in $STACKS
+do  
+    DST=${S3_ROOT}/${TAG}/${STACK}.yaml
+    INFO "uploading ${STACK} to ${DST}"
+    kubectl kustomize ${STACK} | aws s3 cp --acl public-read - ${DST}
+done


### PR DESCRIPTION
It's generally useful to not have to rely on github in order to
distribute our manifest. For CI runs, it's more reliable to just point
at a static manifest hosted in S3. This commit adds a script to build
and mirror manifests to an s3 bucket.