### PR TITLE
feat: allow submitting to http

### DIFF
--- a/bases/events/noop/deployment.yaml
+++ b/bases/events/noop/deployment.yaml
@@ -27,7 +27,7 @@ spec:
           args:
             - -healthz-addr=:5171
             - -metrics-addr=:9090
-            - -o=https://$(OBSERVE_CUSTOMER):$(OBSERVE_TOKEN)@$(OBSERVE_COLLECTOR_HOST):$(OBSERVE_COLLECTOR_PORT)/v1/http/kubernetes/events?clusterUid=$(OBSERVE_CLUSTER)
+            - -o=$(OBSERVE_COLLECTOR_SCHEME)://$(OBSERVE_CUSTOMER):$(OBSERVE_TOKEN)@$(OBSERVE_COLLECTOR_HOST):$(OBSERVE_COLLECTOR_PORT)/v1/http/kubernetes/events?clusterUid=$(OBSERVE_CLUSTER)
           ports:
             - containerPort: 5171
             - containerPort: 9090

--- a/bases/events/noop/kustomization.yaml
+++ b/bases/events/noop/kustomization.yaml
@@ -15,6 +15,7 @@ configMapGenerator:
     literals:
       - OBSERVE_COLLECTOR_HOST=collect.observeinc.com
       - OBSERVE_COLLECTOR_PORT=443
+      - OBSERVE_COLLECTOR_SCHEME=https
       - V=2
 
 images:

--- a/bases/logs/m/fluent-bit.conf
+++ b/bases/logs/m/fluent-bit.conf
@@ -75,7 +75,7 @@
     Alias               k8slogs
     Host                ${OBSERVE_COLLECTOR_HOST}
     Port                ${OBSERVE_COLLECTOR_PORT}
-    TLS                 on
+    TLS                 ${OBSERVE_COLLECTOR_TLS}
     URI                 /v1/http/kubernetes/logs?clusterUid=${OBSERVE_CLUSTER}
     Format              msgpack
     Header              X-Observe-Decoder fluent
@@ -89,7 +89,7 @@
     Alias               k8snode
     Host                ${OBSERVE_COLLECTOR_HOST}
     Port                ${OBSERVE_COLLECTOR_PORT}
-    TLS                 on
+    TLS                 ${OBSERVE_COLLECTOR_TLS}
     URI                 /v1/http/kubernetes/node?clusterUid=${OBSERVE_CLUSTER}
     Format              msgpack
     Header              X-Observe-Decoder fluent

--- a/bases/metrics/base/agent.yaml
+++ b/bases/metrics/base/agent.yaml
@@ -17,7 +17,7 @@ metrics:
       wal_truncate_frequency: ${PROM_WAL_TRUNCATE_FREQUENCY}
       remote_flush_deadline: ${PROM_REMOTE_FLUSH_DEADLINE}
       remote_write:
-        - url: https://${OBSERVE_COLLECTOR_HOST}:${OBSERVE_COLLECTOR_PORT}/v1/prometheus
+        - url: ${OBSERVE_COLLECTOR_SCHEME}://${OBSERVE_COLLECTOR_HOST}:${OBSERVE_COLLECTOR_PORT}/v1/prometheus
           basic_auth:
             username: ${OBSERVE_CUSTOMER}
             password: ${OBSERVE_TOKEN}

--- a/bases/metrics/base/kustomization.yaml
+++ b/bases/metrics/base/kustomization.yaml
@@ -15,6 +15,7 @@ configMapGenerator:
     literals:
       - OBSERVE_COLLECTOR_HOST=collect.observeinc.com
       - OBSERVE_COLLECTOR_PORT=443
+      - OBSERVE_COLLECTOR_SCHEME=https
       - OBSERVE_COLLECTOR_INSECURE=off
       - PROM_BATCH_SEND_DEADLINE=5s
       - PROM_CAPACITY=15000


### PR DESCRIPTION
For testing and development purposes, it can be useful to avoid TLS and
point at an HTTP sink.