### PR TITLE
feat: add traces base

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,12 @@ This will create an `observe` namespace for you and start collecting Kubernetes 
 
 # Components
 
-We provide three "base" components:
+We provide four "base" components:
 
 - `bases/events` - responsible for collecting Kubernetes state using `kube-state-events`
 - `bases/logs` - responsible for collecting container logs using `fluent-bit`
 - `bases/metrics` - responsible for collecting container logs using `grafana-agent`
+- `bases/traces` - responsible for collecting traces using `otel-collector`
 
 We compose these base layers into overlays. Our default `stack` overlay
 collects events, logs and metrics.

--- a/bases/traces/m/config.yaml
+++ b/bases/traces/m/config.yaml
@@ -1,0 +1,45 @@
+---
+exporters:
+  otlphttp:
+    endpoint: "${OBSERVE_COLLECTOR_SCHEME}://${OBSERVE_COLLECTOR_HOST}:${OBSERVE_COLLECTOR_PORT}/v1/otel?clusterUid=${OBSERVE_CLUSTER}"
+    headers:
+      authorization: "Bearer ${OBSERVE_CUSTOMER} ${OBSERVE_TOKEN}"
+    sending_queue:
+      num_consumers: ${OTEL_SENDING_QUEUE}
+      queue_size: ${OTEL_QUEUE_SIZE}
+    retry_on_failure:
+      enabled: ${OTEL_RETRY_ON_FAILURE}
+  prometheusremotewrite:
+    endpoint: "${OBSERVE_COLLECTOR_SCHEME}://${OBSERVE_COLLECTOR_HOST}:${OBSERVE_COLLECTOR_PORT}/v1/otel?clusterUid=${OBSERVE_CLUSTER}"
+    headers:
+      authorization: "Bearer ${OBSERVE_CUSTOMER} ${OBSERVE_TOKEN}"
+extensions:
+  health_check: {}
+  zpages: {}
+processors:
+  batch:
+  memory_limiter:
+    # 80% of maximum memory up to 2G
+    limit_mib: ${OTEL_MEMORY_LIMITER_LIMIT_MIB}
+    # 25% of limit up to 2G
+    spike_limit_mib: ${OTEL_MEMORY_LIMITER_SPIKE_LIMIT_MIB}
+    check_interval: "${OTEL_MEMORY_LIMITER_CHECK_INTERVAL}"
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+service:
+  telemetry:
+    logs:
+      level: "${OTEL_LOG_LEVEL}"
+  extensions: [health_check, zpages]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlphttp]
+    metrics:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [prometheusremotewrite]

--- a/bases/traces/m/deployment.yaml
+++ b/bases/traces/m/deployment.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: traces
+spec:
+  minReadySeconds: 10
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: traces
+  template:
+    metadata:
+      labels:
+        name: traces
+    spec:
+      containers:
+        - name: otel-collector
+          image: otel/opentelemetry-collector-contrib
+          command:
+            - "/otelcol-contrib"
+            - "--config=/etc/config/config.yaml"
+            - "--config=/etc/config/extra.yaml"
+            # for internal prometheus metrics
+            - "--set=service.telemetry.metrics.address=:58888"
+          ports:
+            - containerPort: 55679    # ZPages endpoint.
+            - containerPort: 4317     # Default OpenTelemetry receiver port.
+            - containerPort: 4318     # Default OpenTelemetry HTTP receiver port.
+            - containerPort: 55680    # Default Legacy OpenTelemetry receiver port.
+            - containerPort: 58888    # Internal Prometheus Metrics.
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133     # Health Check extension default port.
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133     # Health Check extension default port.
+          resources:
+            limits:
+              cpu: 500m
+              memory: 500Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          env:
+            - name: OBSERVE_CLUSTER
+              valueFrom:
+                configMapKeyRef:
+                  name: cluster-info
+                  key: id
+          envFrom:
+            - configMapRef:
+                name: otel-collector-env
+            - secretRef:
+                name: credentials
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities:
+              drop:
+                - all
+          volumeMounts:
+            - mountPath: /etc/config
+              name: otel-collector
+      volumes:
+        - name: otel-collector
+          configMap:
+            name: otel-collector

--- a/bases/traces/m/kustomization.yaml
+++ b/bases/traces/m/kustomization.yaml
@@ -1,0 +1,36 @@
+---
+namePrefix: observe-
+
+resources:
+  - service.yaml
+  - deployment.yaml
+
+commonLabels:
+  observeinc.com/component: 'traces'
+
+configMapGenerator:
+  - name: otel-collector-env
+    literals:
+      - OBSERVE_COLLECTOR_HOST=collect.observeinc.com
+      - OBSERVE_COLLECTOR_PORT=443
+      - OBSERVE_COLLECTOR_SCHEME=https
+      - OBSERVE_COLLECTOR_INSECURE=off
+      - OTEL_SENDING_QUEUE=4
+      - OTEL_QUEUE_SIZE=100
+      - OTEL_RETRY_ON_FAILURE=true
+      # 80% of maximum memory up to 2G
+      - OTEL_MEMORY_LIMITER_LIMIT_MIB=400
+      # 25% of limit up to 2G
+      - OTEL_MEMORY_LIMITER_SPIKE_LIMIT_MIB=100
+      - OTEL_MEMORY_LIMITER_CHECK_INTERVAL=5s
+      # known to not work: https://github.com/open-telemetry/opentelemetry-collector/issues/4328
+      - OTEL_LOG_LEVEL=info
+  - name: otel-collector
+    literals:
+      - extra.yaml=
+    files:
+      - config.yaml
+
+images:
+  - name: otel/opentelemetry-collector-contrib
+    newTag: '0.46.0'

--- a/bases/traces/m/service.yaml
+++ b/bases/traces/m/service.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: traces
+spec:
+  ports:
+    - port: 4317
+      targetPort: 4317
+      name: otlp
+    - port: 4318
+      targetPort: 4318
+      name: otlphttp
+    - port: 55680
+      targetPort: 55680
+      name: otlplegacy
+    - port: 55681
+      targetPort: 4318
+      name: otlphttplegacy

--- a/examples/traces/README.md
+++ b/examples/traces/README.md
@@ -1,0 +1,6 @@
+# Tracing
+
+This kustomize manifest exemplifies how to configure a custom processor and add
+it to the pipeline responsible for traces. The configuration example is taken
+from the [tail sampling processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor)
+docs.

--- a/examples/traces/extra.yaml
+++ b/examples/traces/extra.yaml
@@ -1,0 +1,133 @@
+---
+processors:
+  tail_sampling:
+    decision_wait: 10s
+    expected_new_traces_per_sec: 10
+    num_traces: 100
+    policies:
+      -
+        name: test-policy-1
+        type: always_sample
+      -
+        latency:
+          threshold_ms: 5000
+        name: test-policy-2
+        type: latency
+      -
+        name: test-policy-3
+        numeric_attribute:
+          key: key1
+          max_value: 100
+          min_value: 50
+        type: numeric_attribute
+      -
+        name: test-policy-4
+        probabilistic:
+          sampling_percentage: 10
+        type: probabilistic
+      -
+        name: test-policy-5
+        status_code:
+          status_codes:
+            - ERROR
+            - UNSET
+        type: status_code
+      -
+        name: test-policy-6
+        string_attribute:
+          key: key2
+          values:
+            - value1
+            - value2
+        type: string_attribute
+      -
+        name: test-policy-7
+        string_attribute:
+          cache_max_size: 10
+          enabled_regex_matching: true
+          key: key2
+          values:
+            - value1
+            - val*
+        type: string_attribute
+      -
+        name: test-policy-8
+        rate_limiting:
+          spans_per_second: 35
+        type: rate_limiting
+      -
+        name: test-policy-9
+        string_attribute:
+          enabled_regex_matching: true
+          invert_match: true
+          key: http.url
+          values:
+            - \/health
+            - \/metrics
+        type: string_attribute
+      -
+        and:
+          and_sub_policy:
+            -
+              name: test-and-policy-1
+              numeric_attribute:
+                key: key1
+                max_value: 100
+                min_value: 50
+              type: numeric_attribute
+            -
+              name: test-and-policy-2
+              string_attribute:
+                key: key2
+                values:
+                  - value1
+                  - value2
+              type: string_attribute
+        name: and-policy-1
+        type: and
+      -
+        composite:
+          composite_sub_policy:
+            -
+              name: test-composite-policy-1
+              numeric_attribute:
+                key: key1
+                max_value: 100
+                min_value: 50
+              type: numeric_attribute
+            -
+              name: test-composite-policy-2
+              string_attribute:
+                key: key2
+                values:
+                  - value1
+                  - value2
+              type: string_attribute
+            -
+              name: test-composite-policy-3
+              type: always_sample
+          max_total_spans_per_second: 1000
+          policy_order:
+            - test-composite-policy-1
+            - test-composite-policy-2
+            - test-composite-policy-3
+          rate_allocation:
+            -
+              percent: 50
+              policy: test-composite-policy-1
+            -
+              percent: 25
+              policy: test-composite-policy-2
+        name: composite-policy-1
+        type: composite
+service:
+  pipelines:
+    traces:
+      exporters:
+        - otlphttp
+      processors:
+        - tail_sampling
+        - memory_limiter
+        - batch
+      receivers:
+        - otlp

--- a/examples/traces/kustomization.yaml
+++ b/examples/traces/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+namespace: observe
+
+bases:
+  - ../../bases/traces/m
+
+configMapGenerator:
+  - name: otel-collector
+    behavior: merge
+    files:
+      - extra.yaml

--- a/examples/traces/namespace.yaml
+++ b/examples/traces/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: observe
+  labels:
+    observeinc.com/component: stack


### PR DESCRIPTION
Mostly clean port of our existing manifest:

- use contrib instead of otel-collector to allow experimental use of
  more processors
- adjust deprecated config options