### PR TITLE
fix(logs): adjust buffer limit

### DIFF
--- a/bases/logs/l/kustomization.yaml
+++ b/bases/logs/l/kustomization.yaml
@@ -7,3 +7,9 @@ commonLabels:
 
 patchesStrategicMerge:
   - patch.yaml
+
+configMapGenerator:
+  - name: fluent-bit-env
+    behavior: merge
+    literals:
+      - FB_MEM_BUF_LIMIT=20MB

--- a/bases/logs/m/kustomization.yaml
+++ b/bases/logs/m/kustomization.yaml
@@ -26,7 +26,7 @@ configMapGenerator:
       - FB_HC_RETRY_FAILURE_COUNT=5
       - FB_HC_PERIOD=10
       - FB_LOG_LEVEL=warning
-      - FB_MEM_BUF_LIMIT=5MB
+      - FB_MEM_BUF_LIMIT=10MB
       - FB_NODE_LOG_INCLUDE_PATH=/var/log/*.log,/var/log/syslog
       - FB_NODE_LOG_EXCLUDE_PATH=/var/log/kube-apiserver-audit-*.log
       - FB_READ_FROM_HEAD=True

--- a/bases/logs/xl/kustomization.yaml
+++ b/bases/logs/xl/kustomization.yaml
@@ -7,3 +7,9 @@ commonLabels:
 
 patchesStrategicMerge:
   - patch.yaml
+
+configMapGenerator:
+  - name: fluent-bit-env
+    behavior: merge
+    literals:
+      - FB_MEM_BUF_LIMIT=30MB

--- a/bases/logs/xs/kustomization.yaml
+++ b/bases/logs/xs/kustomization.yaml
@@ -7,3 +7,9 @@ commonLabels:
 
 patchesStrategicMerge:
   - patch.yaml
+
+configMapGenerator:
+  - name: fluent-bit-env
+    behavior: merge
+    literals:
+      - FB_MEM_BUF_LIMIT=5MB


### PR DESCRIPTION
The buffer limit should be ~3-4x smaller than the allocated memory.
Undersizing a buffer limit isn't dire, but it does spam logs with
warnings that tailing is paused. This can happen alongside noisy
cronjobs in particular.