### PR TITLE
fix(logs): tighten security context

### DIFF
--- a/bases/logs/m/daemonset.yaml
+++ b/bases/logs/m/daemonset.yaml
@@ -81,6 +81,14 @@ spec:
             - name: varlibdockercontainers
               mountPath: /var/lib/docker/containers
               readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - CAP_FOWNER
       volumes:
         - name: config
           configMap:

--- a/bases/metrics/m/deployment.yaml
+++ b/bases/metrics/m/deployment.yaml
@@ -55,6 +55,12 @@ spec:
           volumeMounts:
             - mountPath: /etc/agent
               name: grafana-agent
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities:
+              drop:
+                - all
       serviceAccountName: metrics
       volumes:
         - name: grafana-agent

--- a/bases/metrics/xl/daemonset.yaml
+++ b/bases/metrics/xl/daemonset.yaml
@@ -63,6 +63,12 @@ spec:
           volumeMounts:
             - mountPath: /etc/agent
               name: grafana-agent
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities:
+              drop:
+                - all
       serviceAccountName: metrics
       volumes:
         - name: grafana-agent


### PR DESCRIPTION
We need to run fluent-bit as root, but can drop all capabilities other
than file-owner