### PR TITLE
fix: add service account for observe-logs

### DIFF
--- a/bases/logs/m/daemonset.yaml
+++ b/bases/logs/m/daemonset.yaml
@@ -17,6 +17,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/path: "/api/v1/metrics/prometheus"
     spec:
+      serviceAccountName: logs
       tolerations:
         - operator: Exists
       affinity:

--- a/bases/logs/m/kustomization.yaml
+++ b/bases/logs/m/kustomization.yaml
@@ -1,6 +1,7 @@
 ---
 resources:
   - daemonset.yaml
+  - serviceaccount.yaml
 
 namePrefix: observe-
 

--- a/bases/logs/m/serviceaccount.yaml
+++ b/bases/logs/m/serviceaccount.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: logs


### PR DESCRIPTION
For completeness, associate a service account to each workload in
observe namespace.