### PR TITLE
fix: default node logs off

### DIFF
--- a/bases/logs/m/kustomization.yaml
+++ b/bases/logs/m/kustomization.yaml
@@ -29,7 +29,7 @@ configMapGenerator:
       - FB_LOG_LEVEL=warning
       - FB_MEM_BUF_LIMIT=10MB
       - FB_NODE_LOG_INCLUDE_PATH=/var/log/*.log,/var/log/syslog
-      - FB_NODE_LOG_EXCLUDE_PATH=/var/log/kube-apiserver-audit-*.log
+      - FB_NODE_LOG_EXCLUDE_PATH=*
       - FB_READ_FROM_HEAD=True
       - FB_REFRESH_INTERVAL=2
       - FB_RETRY_LIMIT=5


### PR DESCRIPTION
Historically we would collect logs from /var/log by omission, but this
requires fluent-bit to be run in privileged security context. Disable by
default. If the data is required, we can always add a new kustomization layer.