### PR TITLE
fix: rollback fluent-bit to v1.8.12

### DIFF
--- a/bases/logs/m/kustomization.yaml
+++ b/bases/logs/m/kustomization.yaml
@@ -40,4 +40,4 @@ configMapGenerator:
 
 images:
   - name: fluent/fluent-bit
-    newTag: '1.8.13'
+    newTag: '1.8.12'


### PR DESCRIPTION
Fluent-bit v1.8.13 has a bug which affects high volume ingest:
https://github.com/fluent/fluent-bit/issues/4991