### PR TITLE
fix: move extras/openshift to examples/openshift

### DIFF
--- a/bases/logs/m/daemonset.yaml
+++ b/bases/logs/m/daemonset.yaml
@@ -85,8 +85,7 @@ spec:
               mountPath: /var/lib/docker/containers
               readOnly: true
           securityContext:
-            allowPrivilegeEscalation: false
-            privileged: false
+            privileged: true
             capabilities:
               drop:
                 - ALL

--- a/examples/openshift/README.md
+++ b/examples/openshift/README.md
@@ -1,0 +1,7 @@
+# OpenShift example
+
+OpenShift requires a few modifications from our base manifest:
+
+- the creation of SecurityContextConstraints for each service account
+- promoting fluent-bit container to `privileged` in order to write tail database to node `/var/log`
+- increasing kube-state-events memory and CPU to deal with large number of API resources

--- a/examples/openshift/constraints.yaml
+++ b/examples/openshift/constraints.yaml
@@ -3,19 +3,20 @@ kind: SecurityContextConstraints
 apiVersion: security.openshift.io/v1
 metadata:
   name: observe-logs
-# Allows fluent-bit to read/write to host's /var/log.
-allowPrivilegedContainer: true
-allowHostNetwork: false
-# Allows fluent-bit to mount host's /var/log using hostPath.
 allowHostDirVolumePlugin: true
-allowHostPorts: false
-allowHostPID: false
 allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: true
+allowedCapabilities:
+  - CAP_FOWNER
 readOnlyRootFilesystem: false
 runAsUser:
   type: RunAsAny
 seLinuxContext:
-  type: MustRunAs
+  type: RunAsAny
 users:
   - system:serviceaccount:observe:observe-logs
 ---

--- a/examples/openshift/kustomization.yaml
+++ b/examples/openshift/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+bases:
+  - ../../stack/m
+
+resources:
+  - constraints.yaml
+
+patchesStrategicMerge:
+  - patch-logs.yaml
+  - patch-events.yaml

--- a/examples/openshift/patch-events.yaml
+++ b/examples/openshift/patch-events.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: events
+spec:
+  template:
+    spec:
+      containers:
+        - name: kube-state-events
+          resources:
+            limits:
+              cpu: 200m
+              memory: 1Gi
+            requests:
+              cpu: 200m
+              memory: 1Gi

--- a/examples/openshift/patch-logs.yaml
+++ b/examples/openshift/patch-logs.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: logs
+spec:
+  template:
+    spec:
+      containers:
+        - name: fluent-bit
+          securityContext:
+            privileged: true

--- a/extras/openshift/kustomization.yaml
+++ b/extras/openshift/kustomization.yaml
@@ -1,6 +1,0 @@
----
-commonLabels:
-  observeinc.com/component: 'openshift'
-
-resources:
-  - constraints.yaml


### PR DESCRIPTION
We need to adjust fluent-bit securityContext in order to be able to
write tail DB to /var/log. We also need to increase kube-state-events
mem and cpu limits.