### PR TITLE
feat: scrape otel-collector metrics

### DIFF
--- a/bases/traces/m/daemonset.yaml
+++ b/bases/traces/m/daemonset.yaml
@@ -41,6 +41,7 @@ spec:
             - containerPort: 4317     # Default OpenTelemetry receiver port.
             - containerPort: 4318     # Default OpenTelemetry HTTP receiver port.
             - containerPort: 58888    # Internal Prometheus Metrics.
+              name: metrics
           livenessProbe:
             httpGet:
               path: /


### PR DESCRIPTION
This should be sufficient to trigger the auto-discovery rules in
grafana-agent