### PR TITLE
fix(traces): remove node filter for k8sattributesprocessor

### DIFF
--- a/bases/traces/m/config.yaml
+++ b/bases/traces/m/config.yaml
@@ -26,8 +26,6 @@ processors:
         action: insert
   k8sattributes:
     passthrough: false
-    filter:
-      node_from_env_var: NODE_NAME
     extract:
       metadata:
         - k8s.pod.name


### PR DESCRIPTION
Traces may end up on any pod within the daemonset, so restricting
tagging to traces that belong to a particular node can be a limiting.
This configuration option is an optimization for larger clusters, and is
a problem we do not yet have for trace collection.