### PR TITLE
fix: adjust xl limits

### DIFF
--- a/stack/xl/kustomization.yaml
+++ b/stack/xl/kustomization.yaml
@@ -2,8 +2,8 @@
 namespace: observe
 
 bases:
-  - ../../bases/events/m
-  - ../../bases/logs/m
+  - ../../bases/events/xl
+  - ../../bases/logs/xl
   - ../../bases/metrics/xl
 
 resources:


### PR DESCRIPTION
We were still referencing `m` sizing for logs and events. This predated
the new sizing limits.