### PR TITLE
feat(metrics): allow signalling pod should not be scraped

### DIFF
--- a/bases/metrics/base/agent.yaml
+++ b/bases/metrics/base/agent.yaml
@@ -54,6 +54,10 @@ metrics:
             - action: 'drop'
               regex: 'false'
               source_labels: ['__meta_kubernetes_pod_annotation_prometheus_io_scrape']
+            # Drop anything annotated with 'observeinc.com.scrape=false'.
+            - action: 'drop'
+              regex: 'false'
+              source_labels: ['__meta_kubernetes_pod_annotation_observeinc_com_scrape']
             # Allow pods to override the scrape scheme with 'prometheus.io.scheme=https'.
             - action: 'replace'
               regex: '(https?)'


### PR DESCRIPTION
Under certain cases we collect more useful telemetry via logs than
metrics. For example, nginx-ingress generates a lot of metrics, all of
which are mostly useless once you are capable of ingesting the raw
access logs. This commit adds the ability to set a
`observeinc.com/scrape` annotation to a pod which behaves in the same
manner as `prometheus.io/scrape`, but targets observe collection
specifically.