### PR TITLE
feat: allow overriding environment variables with configMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Once installed, you can forward traces to the local collector over GRPC on
 
 # Configuration
 
+## Using kustomize
+
 You can override any individual configuration element by creating a new
 kustomized manifest with our kustomized directory as a base.
 
@@ -111,14 +113,39 @@ configMapGenerator:
     literals:
       - FB_DEBUG=true
 EOF
+```
 
+You can then apply this configuration directly from kubectl:
+
+```
 kubectl apply -k $EXAMPLE_DIR
+```
 
-# Of if you prefer using kustomize directly...
+or, alternatively, you can build using your specific `kustomize` version and apply:
+
+```
 kustomize build $EXAMPLE_DIR | kubectl apply -f -
 ```
 
 You can version control your kustomized directory while tracking upstream changes through the use of branch tags.
+
+## Using an override configMap
+
+Alternatively, you can create a configmap in the `observe` namespace containing
+overrides for each of our pods. Following the previous example:
+
+```
+echo "FB_DEBUG=true" >> example.env
+kubectl create configmap -n observe env-overrides --from-env-file example.env
+```
+
+Unlike the kustomize method, configuration changes are not picked up
+automatically. You must restart pods to pick up the new environment variables:
+
+```
+kubectl rollout restart -n observe daemonset
+kubectl rollout restart -n observe deployment
+```
 
 # Pruning and deletion
 

--- a/bases/events/noop/deployment.yaml
+++ b/bases/events/noop/deployment.yaml
@@ -41,6 +41,12 @@ spec:
           envFrom:
             - configMapRef:
                 name: kube-state-events-env
+            - configMapRef:
+                name: kube-state-events-env-overrides
+                optional: true
+            - configMapRef:
+                name: env-overrides
+                optional: true
             - secretRef:
                 name: credentials
           readinessProbe:

--- a/bases/logs/m/daemonset.yaml
+++ b/bases/logs/m/daemonset.yaml
@@ -36,6 +36,12 @@ spec:
           envFrom:
             - configMapRef:
                 name: fluent-bit-env
+            - configMapRef:
+                name: fluent-bit-env-overrides
+                optional: true
+            - configMapRef:
+                name: env-overrides
+                optional: true
             - secretRef:
                 name: credentials
           env:

--- a/bases/metrics/m/deployment.yaml
+++ b/bases/metrics/m/deployment.yaml
@@ -30,6 +30,12 @@ spec:
           envFrom:
             - configMapRef:
                 name: grafana-agent-env
+            - configMapRef:
+                name: grafana-agent-env-overrides
+                optional: true
+            - configMapRef:
+                name: env-overrides
+                optional: true
             - secretRef:
                 name: credentials
           env:

--- a/bases/metrics/xl/daemonset.yaml
+++ b/bases/metrics/xl/daemonset.yaml
@@ -38,6 +38,12 @@ spec:
           envFrom:
             - configMapRef:
                 name: grafana-agent-env
+            - configMapRef:
+                name: grafana-agent-env-overrides
+                optional: true
+            - configMapRef:
+                name: env-overrides
+                optional: true
             - secretRef:
                 name: credentials
           env:

--- a/bases/traces/m/daemonset.yaml
+++ b/bases/traces/m/daemonset.yaml
@@ -71,6 +71,12 @@ spec:
           envFrom:
             - configMapRef:
                 name: otel-collector-env
+            - configMapRef:
+                name: otel-collector-env-overrides
+                optional: true
+            - configMapRef:
+                name: env-overrides
+                optional: true
             - secretRef:
                 name: credentials
           securityContext:


### PR DESCRIPTION
While it is relatively simple to override particular env variables using
kustomize, it is not very convenient if you're not well versed in the
tool. For quick adjustments that persist across updates, it can be
easier to just create a configMap of overrides rather than persist a
kustomization.yaml in a directory and then figure out how to keep track
of changes.

This change adds optional configMap overrides for each of our bases. We
allow for a specific, targeted configMap, or a global `env-overrides`
configMap. Unlike with kustomize, configuration changes won't be
automatically picked up, so a manual rollout is required.