### PR TITLE
fix: reorder envFrom

### DIFF
--- a/bases/events/noop/deployment.yaml
+++ b/bases/events/noop/deployment.yaml
@@ -41,14 +41,14 @@ spec:
           envFrom:
             - configMapRef:
                 name: kube-state-events-env
-            - configMapRef:
-                name: kube-state-events-env-overrides
-                optional: true
+            - secretRef:
+                name: credentials
             - configMapRef:
                 name: env-overrides
                 optional: true
-            - secretRef:
-                name: credentials
+            - configMapRef:
+                name: kube-state-events-env-overrides
+                optional: true
           readinessProbe:
             httpGet:
               path: /healthz

--- a/bases/logs/m/daemonset.yaml
+++ b/bases/logs/m/daemonset.yaml
@@ -36,14 +36,14 @@ spec:
           envFrom:
             - configMapRef:
                 name: fluent-bit-env
-            - configMapRef:
-                name: fluent-bit-env-overrides
-                optional: true
+            - secretRef:
+                name: credentials
             - configMapRef:
                 name: env-overrides
                 optional: true
-            - secretRef:
-                name: credentials
+            - configMapRef:
+                name: fluent-bit-env-overrides
+                optional: true
           env:
             - name: NODE
               valueFrom:

--- a/bases/metrics/m/deployment.yaml
+++ b/bases/metrics/m/deployment.yaml
@@ -30,14 +30,14 @@ spec:
           envFrom:
             - configMapRef:
                 name: grafana-agent-env
-            - configMapRef:
-                name: grafana-agent-env-overrides
-                optional: true
+            - secretRef:
+                name: credentials
             - configMapRef:
                 name: env-overrides
                 optional: true
-            - secretRef:
-                name: credentials
+            - configMapRef:
+                name: grafana-agent-env-overrides
+                optional: true
           env:
             - name: HOSTNAME
               valueFrom:

--- a/bases/metrics/xl/daemonset.yaml
+++ b/bases/metrics/xl/daemonset.yaml
@@ -38,14 +38,14 @@ spec:
           envFrom:
             - configMapRef:
                 name: grafana-agent-env
-            - configMapRef:
-                name: grafana-agent-env-overrides
-                optional: true
+            - secretRef:
+                name: credentials
             - configMapRef:
                 name: env-overrides
                 optional: true
-            - secretRef:
-                name: credentials
+            - configMapRef:
+                name: grafana-agent-env-overrides
+                optional: true
           env:
             - name: HOSTNAME
               valueFrom:

--- a/bases/traces/m/daemonset.yaml
+++ b/bases/traces/m/daemonset.yaml
@@ -71,14 +71,14 @@ spec:
           envFrom:
             - configMapRef:
                 name: otel-collector-env
-            - configMapRef:
-                name: otel-collector-env-overrides
-                optional: true
+            - secretRef:
+                name: credentials
             - configMapRef:
                 name: env-overrides
                 optional: true
-            - secretRef:
-                name: credentials
+            - configMapRef:
+                name: otel-collector-env-overrides
+                optional: true
           securityContext:
             runAsNonRoot: true
             runAsUser: 65534


### PR DESCRIPTION
envFrom applies elements in order, so we want to go from general to must
specific. This implies we should have the individual override (e.g.
`fluent-bit-env-overrides` come after `env-overrides`.