### PR TITLE
feat(logs): support wildcard matching in output

### DIFF
--- a/bases/logs/m/fluent-bit.conf
+++ b/bases/logs/m/fluent-bit.conf
@@ -71,7 +71,7 @@
 
 [OUTPUT]
     Name                http
-    Match               k8slogs
+    Match               k8slogs*
     Alias               k8slogs
     Host                ${OBSERVE_COLLECTOR_HOST}
     Port                ${OBSERVE_COLLECTOR_PORT}
@@ -86,7 +86,7 @@
 
 [OUTPUT]
     Name                http
-    Match               k8snode
+    Match               k8snode*
     Alias               k8snode
     Host                ${OBSERVE_COLLECTOR_HOST}
     Port                ${OBSERVE_COLLECTOR_PORT}

--- a/examples/pre-processing-logs/README.md
+++ b/examples/pre-processing-logs/README.md
@@ -1,0 +1,23 @@
+# Pre-processing logs 
+
+To apply a set of filters to a subset of logs, you will need to use the
+`rewrite_tag` filter to identify the subset of logs you are interested in. In
+this example, we use the following filter:
+
+```
+[FILTER]
+    Name          rewrite_tag
+    Match         k8slogs
+    Rule          $containerName ${CONTAINER_FILTER_REGEX} k8slogs.preprocessing false
+```
+
+In this case, all logs with tag `k8slogs` have their taggen rewritten to
+`k8slogs.preprocessing` if their `containerName` matches the provided regex,
+which in this case is loaded in via the `CONTAINER_FILTER_REGEX` environment
+variable. The final argument of the filter rule is set to `false`, which
+ensures that any matching log is discarded from the original input.
+
+The base fluent-bit configuration ensures we emit logs with any tag starting
+with `k8slogs`, so there is no need to write an additional output for this new
+set of logs.
+

--- a/examples/pre-processing-logs/fluent-bit-extra.conf
+++ b/examples/pre-processing-logs/fluent-bit-extra.conf
@@ -1,0 +1,12 @@
+[FILTER]
+    Name                    rewrite_tag
+    Match                   k8slogs
+    Rule                    $containerName ${CONTAINER_FILTER_REGEX} k8slogs.preprocessing false
+    Emitter_Mem_Buf_Limit   ${FB_MEM_BUF_LIMIT}
+
+[FILTER]
+    Name            lua
+    Match           k8slogs.preprocessing
+    Protected_mode  true
+    script          /fluent-bit/etc/process.lua
+    call            cb_print

--- a/examples/pre-processing-logs/kustomization.yaml
+++ b/examples/pre-processing-logs/kustomization.yaml
@@ -1,0 +1,15 @@
+bases:
+  - ../../stack/xs
+
+configMapGenerator:
+  - name: fluent-bit-config
+    behavior: merge
+    files:
+      - fluent-bit-extra.conf
+      - scripts/process.lua
+
+  - name: fluent-bit-env
+    behavior: merge
+    literals:
+      # match all,
+      - CONTAINER_FILTER_REGEX=.*

--- a/examples/pre-processing-logs/scripts/process.lua
+++ b/examples/pre-processing-logs/scripts/process.lua
@@ -1,0 +1,49 @@
+--[[
+   This Lua script provides 3 interfaces or callbacks for filter_lua:
+   - cb_print   => Print records to the standard output
+   - cb_drop    => Drop the record
+   - cb_replace => Replace record content with a new table
+   The key inside each function is to do a proper handling of the
+   return values. Each function must return 3 values:
+      return code, timestamp, record
+   where:
+   - code     : -1 record must be deleted
+                 0 record not modified, keep the original
+                 1 record was modified, replace timestamp and record.
+                 2 record was modified, replace record and keep timestamp.
+   - timestamp: Unix timestamp with precision (double)
+   - record   : Table with multiple key/val
+   Upon return if code == 1 (modified), then filter_lua plugin
+   will replace the original timestamp and record with the returned
+   values. If code == 0 the original record is kept otherwise if
+   code == -1, the original record will be deleted.
+]]
+
+-- Print record to the standard output
+function cb_print(tag, timestamp, record)
+   output = tag .. ":  [" .. string.format("%f", timestamp) .. ", { "
+
+   for key, val in pairs(record) do
+      output = output .. string.format(" %s => %s,", key, val)
+   end
+   
+   output = string.sub(output,1,-2) .. " }]"
+   print(output)
+
+   -- Record not modified so 'code' return value is 0 (first parameter)
+   return 0, 0, 0
+end
+
+-- Drop the record
+function cb_drop(tag, timestamp, record)
+   return -1, 0, 0
+end
+
+-- Compose a new JSON map and report it
+function cb_replace(tag, timestamp, record)
+   -- Record modified, so 'code' return value (first parameter) is 1
+   new_record = {}
+   new_record["new"] = 12345
+   new_record["old"] = record
+   return 1, timestamp, new_record
+end


### PR DESCRIPTION
When outputting logs, accept any tag that matches a given known prefix.
This enables the usecase where you may want to further process a subset
of logs, for example using some arbitrary lua extension:

```
[FILTER]
    Name          rewrite_tag
    Match         k8slogs
    Rule          $containerName ${CONTAINER_FILTER_REGEX} k8slogs.preprocessing false

[FILTER]
    Name            lua
    Match           k8slogs.preprocessing
    Protected_mode  true
    script          /fluent-bit/etc/process.lua
    call            cb_print
```

Without this change, you would need to write a separate output to export
the new tag `k8slogs.preprocessing`.