### PR TITLE
fix: avoid scheduling on windows nodes

### DIFF
--- a/bases/logs/m/daemonset.yaml
+++ b/bases/logs/m/daemonset.yaml
@@ -29,6 +29,7 @@ spec:
               - matchExpressions:
                   - {key: observeinc.com/unschedulable, operator: DoesNotExist}
                   - {key: eks.amazonaws.com/compute-type, operator: NotIn, values: [fargate]}
+                  - {key: kubernetes.io/os, operator: NotIn, values: [windows]}
       terminationGracePeriodSeconds: 15
       containers:
         - name: fluent-bit

--- a/bases/metrics/xl/daemonset.yaml
+++ b/bases/metrics/xl/daemonset.yaml
@@ -25,6 +25,7 @@ spec:
               - matchExpressions:
                   - {key: observeinc.com/unschedulable, operator: DoesNotExist}
                   - {key: eks.amazonaws.com/compute-type, operator: NotIn, values: [fargate]}
+                  - {key: kubernetes.io/os, operator: NotIn, values: [windows]}
       terminationGracePeriodSeconds: 15
       containers:
         - name: grafana-agent

--- a/bases/traces/m/daemonset.yaml
+++ b/bases/traces/m/daemonset.yaml
@@ -26,6 +26,7 @@ spec:
               - matchExpressions:
                   - {key: observeinc.com/unschedulable, operator: DoesNotExist}
                   - {key: eks.amazonaws.com/compute-type, operator: NotIn, values: [fargate]}
+                  - {key: kubernetes.io/os, operator: NotIn, values: [windows]}
       terminationGracePeriodSeconds: 15
       containers:
         - name: otel-collector


### PR DESCRIPTION
None of our existing daemonsets are tested on windows, make sure we
don't schedule to windows nodes for now.