### PR TITLE
fix: remove OBSERVE_CUSTOMER from collection endpoints since OBSERVE_COLLECTOR_HOST now includes it

### DIFF
--- a/bases/events/noop/deployment.yaml
+++ b/bases/events/noop/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           args:
             - -healthz-addr=:5171
             - -metrics-addr=:9090
-            - -o=$(OBSERVE_COLLECTOR_SCHEME)://$(OBSERVE_TOKEN)@$(OBSERVE_CUSTOMER).$(OBSERVE_COLLECTOR_HOST):$(OBSERVE_COLLECTOR_PORT)/v1/http/kubernetes/events?clusterUid=$(OBSERVE_CLUSTER)
+            - -o=$(OBSERVE_COLLECTOR_SCHEME)://$(OBSERVE_TOKEN)@$(OBSERVE_COLLECTOR_HOST):$(OBSERVE_COLLECTOR_PORT)/v1/http/kubernetes/events?clusterUid=$(OBSERVE_CLUSTER)
           ports:
             - containerPort: 5171
             - containerPort: 9090

--- a/bases/logs/m/fluent-bit.conf
+++ b/bases/logs/m/fluent-bit.conf
@@ -73,7 +73,7 @@
     Name                http
     Match               k8slogs*
     Alias               k8slogs
-    Host                ${OBSERVE_CUSTOMER}.${OBSERVE_COLLECTOR_HOST}
+    Host                ${OBSERVE_COLLECTOR_HOST}
     Port                ${OBSERVE_COLLECTOR_PORT}
     TLS                 ${OBSERVE_COLLECTOR_TLS}
     URI                 /v1/http/kubernetes/logs?clusterUid=${OBSERVE_CLUSTER}
@@ -87,7 +87,7 @@
     Name                http
     Match               k8snode*
     Alias               k8snode
-    Host                ${OBSERVE_CUSTOMER}.${OBSERVE_COLLECTOR_HOST}
+    Host                ${OBSERVE_COLLECTOR_HOST}
     Port                ${OBSERVE_COLLECTOR_PORT}
     TLS                 ${OBSERVE_COLLECTOR_TLS}
     URI                 /v1/http/kubernetes/node?clusterUid=${OBSERVE_CLUSTER}

--- a/bases/metrics/base/agent.yaml
+++ b/bases/metrics/base/agent.yaml
@@ -14,7 +14,7 @@ metrics:
       wal_truncate_frequency: ${PROM_WAL_TRUNCATE_FREQUENCY}
       remote_flush_deadline: ${PROM_REMOTE_FLUSH_DEADLINE}
       remote_write:
-        - url: ${OBSERVE_COLLECTOR_SCHEME}://${OBSERVE_CUSTOMER}.${OBSERVE_COLLECTOR_HOST}:${OBSERVE_COLLECTOR_PORT}/v1/prometheus
+        - url: ${OBSERVE_COLLECTOR_SCHEME}://${OBSERVE_COLLECTOR_HOST}:${OBSERVE_COLLECTOR_PORT}/v1/prometheus
           authorization:
             credentials: ${OBSERVE_TOKEN}
           remote_timeout: ${PROM_REMOTE_TIMEOUT}

--- a/bases/traces/m/config.yaml
+++ b/bases/traces/m/config.yaml
@@ -3,7 +3,7 @@ exporters:
   logging:
     loglevel: "${OTEL_LOG_LEVEL}"
   otlphttp:
-    endpoint: "${OBSERVE_COLLECTOR_SCHEME}://${OBSERVE_CUSTOMER}.${OBSERVE_COLLECTOR_HOST}:${OBSERVE_COLLECTOR_PORT}/v1/otel"
+    endpoint: "${OBSERVE_COLLECTOR_SCHEME}://${OBSERVE_COLLECTOR_HOST}:${OBSERVE_COLLECTOR_PORT}/v1/otel"
     headers:
       authorization: "Bearer ${OBSERVE_TOKEN}"
     sending_queue:
@@ -12,7 +12,7 @@ exporters:
     retry_on_failure:
       enabled: ${OTEL_RETRY_ON_FAILURE}
   prometheusremotewrite:
-    endpoint: "${OBSERVE_COLLECTOR_SCHEME}://${OBSERVE_CUSTOMER}.${OBSERVE_COLLECTOR_HOST}:${OBSERVE_COLLECTOR_PORT}/v1/otel"
+    endpoint: "${OBSERVE_COLLECTOR_SCHEME}://${OBSERVE_COLLECTOR_HOST}:${OBSERVE_COLLECTOR_PORT}/v1/otel"
     headers:
       authorization: "Bearer ${OBSERVE_TOKEN}"
 extensions:

--- a/bases/winlogs/m/fluentd.conf
+++ b/bases/winlogs/m/fluentd.conf
@@ -72,7 +72,7 @@
 
 <match k8slogs.**>
   @type http
-  endpoint "https://#{ENV['OBSERVE_CUSTOMER']}.#{ENV['OBSERVE_COLLECTOR_HOST']}:#{ENV['OBSERVE_COLLECTOR_PORT']}/v1/http/kubernetes/logs?clusterUid=#{ENV['OBSERVE_CLUSTER']}"
+  endpoint "https://#{ENV['OBSERVE_COLLECTOR_HOST']}:#{ENV['OBSERVE_COLLECTOR_PORT']}/v1/http/kubernetes/logs?clusterUid=#{ENV['OBSERVE_CLUSTER']}"
   headers {"Authorization":"Bearer #{ENV['OBSERVE_TOKEN']}"}
   tls_verify_mode "#{ENV['OBSERVE_COLLECTOR_TLS']}"
   <buffer>
@@ -82,7 +82,7 @@
 
 <match k8snode.**>
   @type http
-  endpoint "https://#{ENV['OBSERVE_CUSTOMER']}.#{ENV['OBSERVE_COLLECTOR_HOST']}:#{ENV['OBSERVE_COLLECTOR_PORT']}/v1/http/kubernetes/node?clusterUid=#{ENV['OBSERVE_CLUSTER']}"
+  endpoint "https://#{ENV['OBSERVE_COLLECTOR_HOST']}:#{ENV['OBSERVE_COLLECTOR_PORT']}/v1/http/kubernetes/node?clusterUid=#{ENV['OBSERVE_CLUSTER']}"
   headers {"Authorization":"Bearer #{ENV['OBSERVE_TOKEN']}"}
   tls_verify_mode "#{ENV['OBSERVE_COLLECTOR_TLS']}"
   <buffer>

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -62,7 +62,8 @@ do_apply() {
         },
         "data": {
             "OBSERVE_CUSTOMER": "$(echo -n $OBSERVE_CUSTOMER | base64)",
-            "OBSERVE_TOKEN": "$(echo -n $OBSERVE_TOKEN | base64)"
+            "OBSERVE_TOKEN": "$(echo -n $OBSERVE_TOKEN | base64)",
+            "OBSERVE_COLLECTOR_HOST": "$(echo -n "$OBSERVE_CUSTOMER.collect.observeinc.com" | base64)"
         }
     }
 EOF


### PR DESCRIPTION
## What does this PR do?

removes the `OBSERVE_CUSTOMER` arg from the collection endpoints since the `OBSERVE_COLLECTOR_HOST` arg now includes it prepended by default.

## Motivation

Our current k8s installation instructions in-app will spit out a kubectl command that will include the `OBSERVE_CUSTOMER` value in the `OBSERVE_COLLECTOR_HOST` argument, and this will currently cause the pods to attempt sending data to the wrong endpoint. 

This change should solve this problem.

## Testing

I have not tested this yet myself, but am happy to take suggestions for how to do so. 

