### PR TITLE
feat(logs): add FB_LOGS_GREP_EXCLUDE

### DIFF
--- a/bases/logs/m/fluent-bit.conf
+++ b/bases/logs/m/fluent-bit.conf
@@ -69,6 +69,12 @@
     Whitelist_key       namespace
     Whitelist_key       nodeName
 
+[FILTER]
+    Name                grep
+    Alias               exclude
+    Match               ${FB_GREP_MATCH_TAG}
+    Exclude             ${FB_GREP_EXCLUDE}
+
 @INCLUDE fluent-bit-extra.conf
 
 [OUTPUT]

--- a/bases/logs/m/kustomization.yaml
+++ b/bases/logs/m/kustomization.yaml
@@ -36,6 +36,8 @@ configMapGenerator:
       - FB_REFRESH_INTERVAL=2
       - FB_RETRY_LIMIT=5
       - FB_ROTATE_WAIT=5
+      - FB_GREP_MATCH_TAG="nothing"
+      - FB_GREP_EXCLUDE="nomatch ^$"
       - OBSERVE_COLLECTOR_HOST=collect.observeinc.com
       - OBSERVE_COLLECTOR_PORT=443
       - OBSERVE_COLLECTOR_TLS=on


### PR DESCRIPTION
It can be useful to exclude a given subset of container logs, such as namespace or containerName.