### PR TITLE
feat: add proxy example

### DIFF
--- a/bases/logs/m/fluent-bit.conf
+++ b/bases/logs/m/fluent-bit.conf
@@ -69,6 +69,12 @@
     Whitelist_key       namespace
     Whitelist_key       nodeName
 
+[FILTER]
+    Name                grep
+    Alias               exclude
+    Match               ${FB_GREP_MATCH_TAG}
+    Exclude             ${FB_GREP_EXCLUDE}
+
 @INCLUDE fluent-bit-extra.conf
 
 [OUTPUT]

--- a/bases/logs/m/kustomization.yaml
+++ b/bases/logs/m/kustomization.yaml
@@ -36,6 +36,8 @@ configMapGenerator:
       - FB_REFRESH_INTERVAL=2
       - FB_RETRY_LIMIT=5
       - FB_ROTATE_WAIT=5
+      - FB_GREP_MATCH_TAG="nothing"
+      - FB_GREP_EXCLUDE="nomatch ^$"
       - OBSERVE_COLLECTOR_HOST=collect.observeinc.com
       - OBSERVE_COLLECTOR_PORT=443
       - OBSERVE_COLLECTOR_TLS=on

--- a/examples/proxy/deployment.yaml
+++ b/examples/proxy/deployment.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: proxy
+  labels:
+    name: proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: proxy
+  template:
+    metadata:
+      labels:
+        name: proxy
+    spec:
+      serviceAccountName: proxy
+      containers:
+        - name: proxy
+          image: observeinc/proxy
+          args:
+            - -listen=:8080
+            - -healthz-bind-address=:8082
+            - -target=$(OBSERVE_COLLECTOR_SCHEME)://$(OBSERVE_CUSTOMER).$(OBSERVE_COLLECTOR_HOST):$(OBSERVE_COLLECTOR_PORT)
+            - -bearer-token=$(OBSERVE_TOKEN)
+            - -tag=clusterUid=$(OBSERVE_CLUSTER)
+            - -progress-v=$(PROXY_PROGRESS_V)
+            - -buffer-request-body-size=$(PROXY_BUFFER_REQUEST_BODY_SIZE)
+          ports:
+            - containerPort: 8080
+            - containerPort: 8082
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8082
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8082
+            timeoutSeconds: 5
+            failureThreshold: 10
+          envFrom:
+            - configMapRef:
+                name: proxy-env
+            - secretRef:
+                name: credentials
+            - configMapRef:
+                name: env-overrides
+                optional: true
+            - configMapRef:
+                name: proxy-env-overrides
+                optional: true
+          env:
+            - name: OBSERVE_CLUSTER
+              valueFrom:
+                configMapKeyRef:
+                  name: cluster-info
+                  key: id
+          resources:
+            limits:
+              cpu: 250m
+              memory: 2Gi
+            requests:
+              cpu: 250m
+              memory: 2Gi
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities:
+              drop:
+                - all
+---

--- a/examples/proxy/kustomization.yaml
+++ b/examples/proxy/kustomization.yaml
@@ -1,0 +1,25 @@
+---
+namespace: observe
+
+resources:
+  - deployment.yaml
+  - service.yaml
+  - serviceaccount.yaml
+
+namePrefix: observe-
+
+commonLabels:
+  observeinc.com/component: 'proxy'
+
+configMapGenerator:
+  - name: proxy-env
+    literals:
+      - OBSERVE_COLLECTOR_HOST=collect.observeinc.com
+      - OBSERVE_COLLECTOR_PORT=443
+      - OBSERVE_COLLECTOR_SCHEME=https
+      - PROXY_PROGRESS_V=1
+      - PROXY_BUFFER_REQUEST_BODY_SIZE=25000
+
+images:
+  - name: observeinc/proxy
+    newTag: 'latest'

--- a/examples/proxy/service.yaml
+++ b/examples/proxy/service.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: proxy
+spec:
+  selector:
+    name: proxy
+  ports:
+    - port: 80
+      targetPort: 8080
+      name: http

--- a/examples/proxy/serviceaccount.yaml
+++ b/examples/proxy/serviceaccount.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: proxy


### PR DESCRIPTION
This adds a new base, which deploys a proxy for forwarding traffic directly to Observe. This is intended solely for legacy uses for now.