### PR TITLE
fix(traces): otel-collector as a seperate credential

### DIFF
--- a/bases/traces/daemonset/daemonset.yaml
+++ b/bases/traces/daemonset/daemonset.yaml
@@ -73,7 +73,7 @@ spec:
             - configMapRef:
                 name: otel-collector-env
             - secretRef:
-                name: credentials
+                name: otel-credentials
             - configMapRef:
                 name: env-overrides
                 optional: true

--- a/bases/traces/deployment/deployment.yaml
+++ b/bases/traces/deployment/deployment.yaml
@@ -73,7 +73,7 @@ spec:
             - configMapRef:
                 name: otel-collector-env
             - secretRef:
-                name: credentials
+                name: otel-credentials
             - configMapRef:
                 name: env-overrides
                 optional: true

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -66,7 +66,29 @@ do_apply() {
         }
     }
 EOF
-)
+    )
+    INFO "Creating otel secret"
+    # this is an arcane way of doing things, but it allows overwriting existing secret without
+    # relying on kubectl --dry-run semantics, which is version dependent
+    RESULT=$(kubectl apply -f - << EOF
+    {
+        "kind": "Secret",
+        "apiVersion": "v1",
+        "metadata": {
+            "name": "otel-credentials",
+            "namespace": "observe",
+            "annotations": {
+                "kubectl.kubernetes.io/last-applied-configuration": ""
+            }
+        },
+        "data": {
+            "OBSERVE_CUSTOMER": "$(echo -n $OBSERVE_CUSTOMER | base64)",
+            "OBSERVE_TOKEN": "$(echo -n $OBSERVE_TOKEN | base64)"
+        }
+    }
+EOF
+    )
+
     DEBUG "$RESULT"
 
     INFO "Waiting on pods to be ready"


### PR DESCRIPTION
This will change the credentials used by the otel-collector deployment and daemonset to require the `otel-credentials` secret which should be an OBSERVE_TOKEN and OBSERVE_CUSTOMER filled with the respective Bearer token generated in the OpenTelemetry App and and Customer name as expected.

=== Test Plan ===
```
kubectl -n observe port-forward service/observe-traces 4317:4317
 01:32:50  INT ❯ echo ${OBSERVE_TOKEN?}
ds11GXA...R53azVlbGz:......mSUU8KBIz1VXDQGJ3b--euxWRf
──────────────────────────────────────────────────────────────────────────────────────────────────────────
 01:32:59 ✔ ❯ kubectl -n observe create secret generic otel-credentials \
        --from-literal=OBSERVE_CUSTOMER=${OBSERVE_CUSTOMER?} \
        --from-literal=OBSERVE_TOKEN=${OBSERVE_TOKEN?}

secret/otel-credentials created

kubectl get pods -n observe
NAME                                               READY   STATUS    RESTARTS   AGE
observe-events-7d6f99b68f-d5jtv                    1/1     Running   0          19m
observe-logs-ndl9n                                 1/1     Running   0          19m
observe-metrics-859844d564-wvs26                   1/1     Running   0          19m
observe-opentelemetry-collector-666f7dfb5c-2fnln

kubectl -n observe port-forward service/observe-traces 4318:4318
curl -i http://localhost:4318/v1/traces -X POST -H "Content-Type: application/json" -d @span.json
HTTP/1.1 200 OK
Content-Type: application/json
Date: Wed, 09 Nov 2022 18:04:04 GMT
Content-Length: 21

{"partialSuccess":{}}%
```

Note for testing: otel-credential may need an additional literal for point to a sandbox
--from-literal=OBSERVE_COLLECTOR_HOST="collect.observe-sandbox.com"
