### PR TITLE
fix(traces): reintroduce observe- prefix

### DIFF
--- a/bases/traces/base/kustomization.yaml
+++ b/bases/traces/base/kustomization.yaml
@@ -22,7 +22,7 @@ configMapGenerator:
       - OTEL_RETRY_ON_FAILURE=true
       - OTEL_SAMPLER_HASH_SEED=22
       - OTEL_SAMPLER_PERCENTAGE=100
-      # 80% of maximum memory up to 2G. 
+      # 80% of maximum memory up to 2G.
       # Must be less than limit or gc will never run
       - OTEL_MEMORY_LIMITER_LIMIT_MIB=192
       # 25% of limit up to 2G

--- a/bases/traces/daemonset/kustomization.yaml
+++ b/bases/traces/daemonset/kustomization.yaml
@@ -2,9 +2,10 @@
 bases:
   - ../base
 
+namePrefix: observe-
+
 commonLabels:
   observeinc.com/component: 'traces'
 
 resources:
   - daemonset.yaml
-

--- a/bases/traces/deployment/deployment.yaml
+++ b/bases/traces/deployment/deployment.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: observe-opentelemetry-collector
+  name: traces
   labels:
     helm.sh/chart: opentelemetry-collector-0.37.2
     app.kubernetes.io/name: opentelemetry-collector
@@ -34,7 +34,7 @@ spec:
       securityContext:
         {}
       containers:
-        - name: observe-traces
+        - name: otel-collector
           command:
             - "/otelcol-contrib"
             - "--config=/etc/config/config.yaml"

--- a/bases/traces/deployment/kustomization.yaml
+++ b/bases/traces/deployment/kustomization.yaml
@@ -2,9 +2,10 @@
 bases:
   - ../base
 
+namePrefix: observe-
+
 resources:
   - deployment.yaml
 
 commonLabels:
   observeinc.com/component: 'traces'
-

--- a/bases/traces/l/patch.yaml
+++ b/bases/traces/l/patch.yaml
@@ -1,12 +1,12 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: observe-opentelemetry-collector
+  name: traces
 spec:
   template:
     spec:
       containers:
-        - name: observe-traces
+        - name: otel-collector
           resources:
             limits:
               cpu: 250m

--- a/bases/traces/m/kustomization.yaml
+++ b/bases/traces/m/kustomization.yaml
@@ -4,4 +4,3 @@ bases:
 
 commonLabels:
   observeinc.com/component: 'traces'
-


### PR DESCRIPTION
We tend to name our controllers observe-<bla>, and make the top level naming independent of the containers that implement functionality.