### PR TITLE
fix(traces): remove superfluous prefixing

### DIFF
--- a/bases/traces/base/kustomization.yaml
+++ b/bases/traces/base/kustomization.yaml
@@ -1,6 +1,4 @@
 ---
-namePrefix: observe-
-
 resources:
   - clusterrole.yaml
   - clusterrolebinding.yaml


### PR DESCRIPTION
When we introduced a new shim base (deployment, daemonset), we did not prefix them accordingly. #84 reintroduced the observe- prefix for the resulting controllers, but inadvertently double-prefixed all resources coming in from base/.

This PR fixes things by removing prefixing from base/kustomization.yaml. You can't build a usable traces stack without one of daemonset or deployment, so gate things on either of those layers.