### PR TITLE
fix(metrics): export prom metrics from grafana-agent

### DIFF
--- a/bases/metrics/m/deployment.yaml
+++ b/bases/metrics/m/deployment.yaml
@@ -30,6 +30,7 @@ spec:
           image: grafana/agent:latest
           imagePullPolicy: IfNotPresent
           args:
+            - -server.http.address=0.0.0.0:12345
             - -config.file=/etc/agent/agent.yaml
             - -config.expand-env
             - -disable-reporting

--- a/bases/metrics/xl/daemonset.yaml
+++ b/bases/metrics/xl/daemonset.yaml
@@ -32,6 +32,7 @@ spec:
           image: grafana/agent:latest
           imagePullPolicy: IfNotPresent
           args:
+            - -server.http.address=0.0.0.0:12345
             - -config.file=/etc/agent/agent.yaml
             - -config.expand-env
             - -disable-reporting


### PR DESCRIPTION
This fixes a regression introduced in beaa64f2 . The server config block was deprecated in 0.26.x, and should instead be provided via command line args. Without this setting, grafana-agent does not expose prometheus metrics over HTTP.