### PR TITLE
feat(metrics): protect against cardinality explosion

### DIFF
--- a/bases/metrics/base/agent.yaml
+++ b/bases/metrics/base/agent.yaml
@@ -31,6 +31,8 @@ metrics:
       scrape_configs:
         - job_name: "integrations/kubernetes/pods"
           bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          sample_limit: ${PROM_SCRAPE_SAMPLE_LIMIT}
+          body_size_limit: ${PROM_SCRAPE_BODY_SIZE_LIMIT}
           kubernetes_sd_configs:
             - role: pod
           relabel_configs:
@@ -128,6 +130,8 @@ metrics:
 
         - job_name: "integrations/kubernetes/kubelet"
           bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          sample_limit: ${PROM_SCRAPE_SAMPLE_LIMIT}
+          body_size_limit: ${PROM_SCRAPE_BODY_SIZE_LIMIT}
           kubernetes_sd_configs:
             - role: node
           relabel_configs:
@@ -156,6 +160,8 @@ metrics:
 
         - job_name: "integrations/kubernetes/resource"
           bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          sample_limit: ${PROM_SCRAPE_SAMPLE_LIMIT}
+          body_size_limit: ${PROM_SCRAPE_BODY_SIZE_LIMIT}
           kubernetes_sd_configs:
             - role: node
           relabel_configs:
@@ -184,6 +190,8 @@ metrics:
 
         - job_name: "integrations/kubernetes/cadvisor"
           bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          sample_limit: ${PROM_SCRAPE_SAMPLE_LIMIT}
+          body_size_limit: ${PROM_SCRAPE_BODY_SIZE_LIMIT}
           kubernetes_sd_configs:
             - role: node
           relabel_configs:

--- a/bases/metrics/base/kustomization.yaml
+++ b/bases/metrics/base/kustomization.yaml
@@ -29,6 +29,7 @@ configMapGenerator:
       - PROM_REMOTE_FLUSH_DEADLINE=1m
       - PROM_SCRAPE_INTERVAL=15s
       - PROM_SCRAPE_TIMEOUT=10s
+      - PROM_SCRAPE_BODY_SIZE_LIMIT=50MB
       - PROM_SCRAPE_CADVISOR_ACTION=keep
       # the following metrics are exported with 0 values in default cadvisor installs
       # see
@@ -48,4 +49,5 @@ configMapGenerator:
       - PROM_SCRAPE_RESOURCE_ACTION=keep
       - PROM_SCRAPE_RESOURCE_METRIC_DROP_REGEX=
       - PROM_SCRAPE_RESOURCE_METRIC_KEEP_REGEX=(.*)
+      - PROM_SCRAPE_SAMPLE_LIMIT=100000
       - PROM_WAL_TRUNCATE_FREQUENCY=30m


### PR DESCRIPTION
Add configuration variables for limiting the number of samples and body size per scrape. This is primarily intended to protect against cardinality explosion. If a given target has an unbounded increase in the number of samples, we should try to error out rather than run into OOMs.

The configured bounds are conservative, but may still lead to false positives, such as in the case of `kube-state-metrics` running in a very large cluster. We happen to not need that data however since we collect state data separately, so we end up erring on the side of caution.