### PR TITLE
feat(logs): allow disabling inotify_watcher

### DIFF
--- a/bases/logs/m/fluent-bit.conf
+++ b/bases/logs/m/fluent-bit.conf
@@ -28,6 +28,7 @@
     Buffer_Max_Size     ${FB_BUFFER_MAX_SIZE}
     Rotate_Wait         ${FB_ROTATE_WAIT}
     Refresh_Interval    ${FB_REFRESH_INTERVAL}
+    Inotify_Watcher     ${FB_INOTIFY_WATCHER}
 
 [INPUT]
     Name                tail
@@ -43,6 +44,7 @@
     Buffer_Chunk_Size   ${FB_BUFFER_CHUNK_SIZE}
     Buffer_Max_Size     ${FB_BUFFER_MAX_SIZE}
     Rotate_Wait         ${FB_ROTATE_WAIT}
+    Inotify_Watcher     ${FB_INOTIFY_WATCHER}
 
 [FILTER]
     Name                record_modifier

--- a/bases/logs/m/kustomization.yaml
+++ b/bases/logs/m/kustomization.yaml
@@ -38,6 +38,7 @@ configMapGenerator:
       - FB_ROTATE_WAIT=5
       - FB_GREP_MATCH_TAG="nothing"
       - FB_GREP_EXCLUDE="nomatch ^$"
+      - FB_INOTIFY_WATCHER=true
       - OBSERVE_COLLECTOR_HOST=collect.observeinc.com
       - OBSERVE_COLLECTOR_PORT=443
       - OBSERVE_COLLECTOR_TLS=on


### PR DESCRIPTION
Under heavy load fluentbit can run into issues when collecting logs out of symlinked directory: https://github.com/fluent/fluent-bit/issues/2110

This commit allows disabling inotify_watcher. We can switch default once we've confirmed there are no other regressions associated to the change.