### PR TITLE
fix(traces) Update trace deployment to include environment k8s attrib

### DIFF
--- a/bases/traces/deployment/deployment.yaml
+++ b/bases/traces/deployment/deployment.yaml
@@ -64,11 +64,15 @@ spec:
               containerPort: 9411
               protocol: TCP
           env:
-            - name: MY_POD_IP
+            - name: NODE_NAME
               valueFrom:
                 fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.podIP
+                  fieldPath: spec.nodeName
+            - name: OBSERVE_CLUSTER
+              valueFrom:
+                configMapKeyRef:
+                  name: cluster-info
+                  key: id
           envFrom:
             - configMapRef:
                 name: otel-collector-env


### PR DESCRIPTION
This is for https://observe.atlassian.net/browse/OB-14844. Fixing the deployment>
Test Plan: 
```
$ KUSTOMIZE_DIR=stack/otel/l make apply
$ kubectl -n observe get deployment.apps observe-traces -o yaml
```
```yaml
  template:
    metadata:
      creationTimestamp: null
      labels:
        app.kubernetes.io/instance: observe-traces
        app.kubernetes.io/name: opentelemetry-collector
        component: standalone-collector
        observeinc.com/component: traces
    spec:
      containers:
      - command:
        - /otelcol-contrib
        - --config=/etc/config/config.yaml
        - --config=/etc/config/extra.yaml
        - --set=service.telemetry.metrics.address=:58888
        env:
        - name: NODE_NAME
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: spec.nodeName
        - name: OBSERVE_CLUSTER
          valueFrom:
            configMapKeyRef:
              key: id
              name: cluster-info
        envFrom:
```