### PR TITLE
feat: allow enabling of storage metrics

### DIFF
--- a/bases/logs/m/fluent-bit.conf
+++ b/bases/logs/m/fluent-bit.conf
@@ -13,6 +13,7 @@
     HC_Period              ${FB_HC_PERIOD}
     dns.mode               ${FB_DNS_MODE}
     dns.resolver           ${FB_DNS_RESOLVER}
+    storage.metrics        ${FB_STORAGE_METRICS}
 
 [INPUT]
     Name                tail

--- a/bases/logs/m/kustomization.yaml
+++ b/bases/logs/m/kustomization.yaml
@@ -36,6 +36,7 @@ configMapGenerator:
       - FB_REFRESH_INTERVAL=2
       - FB_RETRY_LIMIT=5
       - FB_ROTATE_WAIT=5
+      - FB_STORAGE_METRICS=Off
       - FB_GREP_MATCH_TAG="nothing"
       - FB_GREP_EXCLUDE="nomatch ^$"
       - FB_INOTIFY_WATCHER=true


### PR DESCRIPTION
Enabling `storage.metrics` in the `SERVICE` section exposes useful debugging info under `/api/v1/storage`.