### PR TITLE
feat(metrics): make metrics endpoint port name matching configurable

### DIFF
--- a/bases/metrics/README.md
+++ b/bases/metrics/README.md
@@ -95,8 +95,11 @@ The `integrations/kubernetes/pods` job uses service discovery to determine what 
      annotations:
        prometheus.io/port: "9999"
     ```
-- expose the metrics endpoint through a port with a name ending with metrics. For example:
+- expose the metrics endpoint through a port with a name matching a configured regex (`.*metrics` by default). For example:
+    ```yaml
+    - PROM_SCRAPE_POD_PORT_KEEP_REGEX=.*metrics
     ```
+    ```yaml
     ports:
     - containerPort: 9999
       name: metrics

--- a/bases/metrics/base/agent.yaml
+++ b/bases/metrics/base/agent.yaml
@@ -37,16 +37,18 @@ metrics:
             - role: pod
           relabel_configs:
             - action: ${PROM_SCRAPE_POD_ACTION}
-            # Drop any endpoint whose pod port name does not end with metrics, or does not have an explicit prometheus port annotation.
+            # Drop anything matching the configured namespace.
             - action: 'drop'
               source_labels: ['__meta_kubernetes_namespace']
               regex: ${PROM_SCRAPE_POD_NAMESPACE_DROP_REGEX}
+            # Drop anything not matching the configured namespace.
             - action: 'keep'
               source_labels: ['__meta_kubernetes_namespace']
               regex: ${PROM_SCRAPE_POD_NAMESPACE_KEEP_REGEX}
+            # Drop endpoints without one of: a port name suffixed with the configured regex, or an explicit prometheus port annotation.
             - action: 'keep'
               source_labels: ['__meta_kubernetes_pod_container_port_name', '__meta_kubernetes_pod_annotation_prometheus_io_port']
-              regex: '.*(metrics;|;\d+)'
+              regex: '(${PROM_SCRAPE_POD_PORT_KEEP_REGEX};|.*;\d+)'
             # Drop pods without a name label.
             # - action: 'drop'
             #   regex: ''

--- a/bases/metrics/base/kustomization.yaml
+++ b/bases/metrics/base/kustomization.yaml
@@ -44,6 +44,7 @@ configMapGenerator:
       - PROM_SCRAPE_POD_ACTION=keep
       - PROM_SCRAPE_POD_NAMESPACE_DROP_REGEX=(.*istio.*|.*ingress.*|kube-system)
       - PROM_SCRAPE_POD_NAMESPACE_KEEP_REGEX=(.*)
+      - PROM_SCRAPE_POD_PORT_KEEP_REGEX=.*metrics
       - PROM_SCRAPE_POD_METRIC_DROP_REGEX=.*bucket
       - PROM_SCRAPE_POD_METRIC_KEEP_REGEX=(.*)
       - PROM_SCRAPE_RESOURCE_ACTION=keep


### PR DESCRIPTION
This change allows users to configure a port name regex to be used for service discovery, rather than expecting metrics ports to be suffixed with `metrics`.