### PR TITLE
fix: revert otel pod_association config change

### DIFF
--- a/bases/traces/base/config.yaml
+++ b/bases/traces/base/config.yaml
@@ -34,10 +34,9 @@ processors:
         - k8s.pod.name
         - k8s.namespace.name
     pod_association:
-      - sources:
-        - from: resource_attribute
-          name: k8s.pod.ip
-        - from: connection
+      - from: resource_attribute
+        name: k8s.pod.ip
+      - from: connection
   batch:
   memory_limiter:
     # 80% of maximum memory up to 2G


### PR DESCRIPTION
- This reverts the previous change to the otel config which breaks the pod associations.
- The config change is only required for >= v0.74 of the collector. Reverting the change for now from main.
