### PR TITLE
fix(winlogs): record node name in logs

### DIFF
--- a/bases/winlogs/m/fluentd.conf
+++ b/bases/winlogs/m/fluentd.conf
@@ -46,7 +46,7 @@
 <filter k8slogs.**>
   @type record_transformer
   <record>
-    nodeName "${hostname}"
+    nodeName "#{ENV['NODE']}"
   </record>
 </filter>
 


### PR DESCRIPTION
Previously we were using hostname, which is set to the pod name. This resulted in links from container logs to node being incorrectly populated.