### PR TITLE
fix(winlogs): pass token in query parameter

### DIFF
--- a/bases/winlogs/m/fluentd.conf
+++ b/bases/winlogs/m/fluentd.conf
@@ -72,8 +72,7 @@
 
 <match k8slogs.**>
   @type http
-  endpoint "https://#{ENV['OBSERVE_CUSTOMER']}.#{ENV['OBSERVE_COLLECTOR_HOST']}:#{ENV['OBSERVE_COLLECTOR_PORT']}/v1/http/kubernetes/logs?clusterUid=#{ENV['OBSERVE_CLUSTER']}"
-  headers {"Authorization":"Bearer #{ENV['OBSERVE_TOKEN']}"}
+  endpoint "https://#{ENV['OBSERVE_CUSTOMER']}.#{ENV['OBSERVE_COLLECTOR_HOST']}:#{ENV['OBSERVE_COLLECTOR_PORT']}/v1/http/kubernetes/logs?clusterUid=#{ENV['OBSERVE_CLUSTER']}&observe_token=#{ENV['OBSERVE_TOKEN']}"
   tls_verify_mode "#{ENV['OBSERVE_COLLECTOR_TLS']}"
   <buffer>
     flush_interval 5s
@@ -82,8 +81,7 @@
 
 <match k8snode.**>
   @type http
-  endpoint "https://#{ENV['OBSERVE_CUSTOMER']}.#{ENV['OBSERVE_COLLECTOR_HOST']}:#{ENV['OBSERVE_COLLECTOR_PORT']}/v1/http/kubernetes/node?clusterUid=#{ENV['OBSERVE_CLUSTER']}"
-  headers {"Authorization":"Bearer #{ENV['OBSERVE_TOKEN']}"}
+  endpoint "https://#{ENV['OBSERVE_CUSTOMER']}.#{ENV['OBSERVE_COLLECTOR_HOST']}:#{ENV['OBSERVE_COLLECTOR_PORT']}/v1/http/kubernetes/logs?clusterUid=#{ENV['OBSERVE_CLUSTER']}&observe_token=#{ENV['OBSERVE_TOKEN']}"
   tls_verify_mode "#{ENV['OBSERVE_COLLECTOR_TLS']}"
   <buffer>
     flush_interval 5s


### PR DESCRIPTION
This commit changes the authentication method from Bearer token to query parameter.

Some versions of Fluentd do not support interpolating environment variables in the `headers` map.

We could instead use basic auth, but that would require us to split the datatream token in the id (username) and the secret (password). This cannot be easily done in either the configuration file or Kubernetes.

This leaves the query parameter option as the best remaining solution. We already know string interpolation works correctly for string fields, so we can attach the token there.