### PR TITLE
fix: add clusteruid to prometheus endpoint

### DIFF
--- a/bases/metrics/base/agent.yaml
+++ b/bases/metrics/base/agent.yaml
@@ -7,8 +7,6 @@ metrics:
   global:
     scrape_interval: ${PROM_SCRAPE_INTERVAL}
     scrape_timeout: ${PROM_SCRAPE_TIMEOUT}
-    external_labels:
-      clusterUid: ${OBSERVE_CLUSTER}
   configs:
     - name: integrations
       host_filter: ${PROM_HOST_FILTER}
@@ -17,7 +15,7 @@ metrics:
       wal_truncate_frequency: ${PROM_WAL_TRUNCATE_FREQUENCY}
       remote_flush_deadline: ${PROM_REMOTE_FLUSH_DEADLINE}
       remote_write:
-        - url: ${OBSERVE_COLLECTOR_SCHEME}://${OBSERVE_CUSTOMER}.${OBSERVE_COLLECTOR_HOST}:${OBSERVE_COLLECTOR_PORT}/v1/prometheus
+        - url: ${OBSERVE_COLLECTOR_SCHEME}://${OBSERVE_CUSTOMER}.${OBSERVE_COLLECTOR_HOST}:${OBSERVE_COLLECTOR_PORT}/v1/prometheus?clusterUid=${OBSERVE_CLUSTER}
           authorization:
             credentials: ${OBSERVE_TOKEN}
           remote_timeout: ${PROM_REMOTE_TIMEOUT}


### PR DESCRIPTION
This PR to add clusterUid to prometheus remote_rewrite to include the tags for the prometheus metadata that is pushed to by grafana-agent.

Have tested the change in eng. 
<img width="1710" alt="Screen Shot 2023-08-04 at 10 51 03 AM" src="https://github.com/observeinc/manifests/assets/127884651/89311d4e-60a7-4ced-a1c9-98c4451f26c3">


Related JIRA - https://observe.atlassian.net/browse/CON-1717 & https://observe.atlassian.net/browse/OB-21039

https://101.observe-eng.com/workspace/41000011/dataset/event/Observation-41046423?filter-OBSERVATION_KIND=prom_md&s=3380-1hn05klz