### PR TITLE
feat/update-grafana-agent-0.36.1

### DIFF
--- a/bases/metrics/m/kustomization.yaml
+++ b/bases/metrics/m/kustomization.yaml
@@ -12,4 +12,4 @@ commonLabels:
 
 images:
   - name: grafana/agent
-    newTag: 'v0.28.1'
+    newTag: 'v0.36.1'


### PR DESCRIPTION
Update the Grafana Agent to the most recent version 0.36.1