### PR TITLE
feat/upgrade grafana agent 0.36.1

### DIFF
--- a/bases/metrics/m/deployment.yaml
+++ b/bases/metrics/m/deployment.yaml
@@ -35,7 +35,7 @@ spec:
             - -config.expand-env
             - -disable-reporting
           command:
-            - /bin/agent
+            - /bin/grafana-agent
           envFrom:
             - configMapRef:
                 name: grafana-agent-env

--- a/bases/metrics/m/kustomization.yaml
+++ b/bases/metrics/m/kustomization.yaml
@@ -12,4 +12,4 @@ commonLabels:
 
 images:
   - name: grafana/agent
-    newTag: 'v0.28.1'
+    newTag: 'v0.36.1'

--- a/bases/metrics/xl/daemonset.yaml
+++ b/bases/metrics/xl/daemonset.yaml
@@ -37,7 +37,7 @@ spec:
             - -config.expand-env
             - -disable-reporting
           command:
-            - /bin/agent
+            - /bin/grafana-agent
           envFrom:
             - configMapRef:
                 name: grafana-agent-env


### PR DESCRIPTION
This PR updates to the latest Grafana agent version and updates the binary name to `grafana-agent`