### PR TITLE
feat: upgrade grafana-agent to 0.36.1

### DIFF
--- a/bases/metrics/xl/kustomization.yaml
+++ b/bases/metrics/xl/kustomization.yaml
@@ -12,4 +12,4 @@ commonLabels:
 
 images:
   - name: grafana/agent
-    newTag: 'v0.28.1'
+    newTag: 'v0.36.1'


### PR DESCRIPTION
This fixes the missing agent upgrade in the xl stack