### PR TITLE
chore: automate updates via updatecli and gha

### DIFF
--- a/.github/workflows/update-deps.yaml
+++ b/.github/workflows/update-deps.yaml
@@ -1,11 +1,9 @@
 name: Update via Updatecli
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * 0'  # Every Sunday at midnight
-  push:
-    branches:
-      - ci/automated-updates
 
 jobs:
   update:
@@ -13,20 +11,23 @@ jobs:
     steps:
       # Checkout the repository
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # Install and run updatecli
       - name: Setup updatecli
         uses: updatecli/updatecli-action@v2
 
       - name: Run updatecli
-        run: updatecli apply --config updatecli/
+        run: |
+          for config in updatecli/*.yaml; do
+            updatecli apply --config $config
+          done
         env:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Use Peter Evans Pull Request Action to create a pull request
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore(deps): Update dependencies"

--- a/.github/workflows/update-deps.yaml
+++ b/.github/workflows/update-deps.yaml
@@ -1,0 +1,38 @@
+name: Update via Updatecli
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # Every Sunday at midnight
+  push:
+    branches:
+      - ci/automated-updates
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout the repository
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # Install and run updatecli
+      - name: Setup updatecli
+        uses: updatecli/updatecli-action@v2
+
+      - name: Run updatecli
+        run: updatecli apply --config updatecli/
+        env:
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Use Peter Evans Pull Request Action to create a pull request
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore(deps): Update dependencies"
+          title: 'chore(deps): Update dependencies'
+          body: |
+            Updates dependencies using `updatecli`.
+          branch: automated-update-${{ github.run_number }}
+          labels: automated-pr, update
+          draft: false

--- a/updatecli/fluent-bit.yaml
+++ b/updatecli/fluent-bit.yaml
@@ -35,5 +35,5 @@ targets:
       key: "images[0].newTag"
     sourceid: FluentBitRelease
     transformers:
-      - addprefix: "'"
+      - addprefix: "'v"
       - addsuffix: "'"

--- a/updatecli/fluent-bit.yaml
+++ b/updatecli/fluent-bit.yaml
@@ -35,5 +35,5 @@ targets:
       key: "images[0].newTag"
     sourceid: FluentBitRelease
     transformers:
-      - addprefix: "'v"
+      - addprefix: "'"
       - addsuffix: "'"

--- a/updatecli/fluent-bit.yaml
+++ b/updatecli/fluent-bit.yaml
@@ -24,14 +24,14 @@ conditions:
     name: "Check if there is a difference in version"
     kind: shell
     spec:
-      command: sh -c '! grep -q {{ source `FluentBitRelease` }} bases/metrics/m/kustomization.yaml'
+      command: sh -c '! grep -q {{ source `FluentBitRelease` }} bases/logs/m/kustomization.yaml'
 
 targets:
   updateKustomizationFile:
     name: "Update kustomization.yaml"
     kind: yaml
     spec:
-      file: "bases/metrics/m/kustomization.yaml"
+      file: "bases/logs/m/kustomization.yaml"
       key: "images[0].newTag"
     sourceid: FluentBitRelease
     transformers:

--- a/updatecli/fluent-bit.yaml
+++ b/updatecli/fluent-bit.yaml
@@ -1,0 +1,39 @@
+# updatecli.yaml
+sources:
+  FluentBitRelease:
+    kind: "githubrelease"
+    spec:
+      owner: "fluent"
+      repository: "fluent-bit"
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+      # Added to take care of "v" prefix in version until the chart is updated to use the semver versioning (which doesn't have the "v" prefix)
+      versionFilter:
+        kind: "semver"
+        allowPrerelease: false
+    transformers:
+      - trimprefix: "v"
+
+conditions:
+  dockerimageExists:
+    name: "Docker Image exists"
+    kind: dockerimage
+    sourceid: FluentBitRelease
+    spec:
+      image: "fluent/fluent-bit"
+  checkDifference:
+    name: "Check if there is a difference in version"
+    kind: shell
+    spec:
+      command: sh -c '! grep -q {{ source `FluentBitRelease` }} bases/metrics/m/kustomization.yaml'
+
+targets:
+  updateKustomizationFile:
+    name: "Update kustomization.yaml"
+    kind: yaml
+    spec:
+      file: "bases/metrics/m/kustomization.yaml"
+      key: "images[0].newTag"
+    sourceid: FluentBitRelease
+    transformers:
+      - addprefix: "'"
+      - addsuffix: "'"

--- a/updatecli/grafana.yaml
+++ b/updatecli/grafana.yaml
@@ -1,0 +1,47 @@
+# updatecli.yaml
+sources:
+  GrafanaRelease:
+    kind: "githubrelease"
+    spec:
+      owner: "grafana"
+      repository: "agent"
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+      # Added to take care of "v" prefix in version until the chart is updated to use the semver versioning (which doesn't have the "v" prefix)
+      versionFilter:
+        kind: "semver"
+        allowPrerelease: false
+
+conditions:
+  dockerimageExists:
+    name: "Docker Image exists"
+    kind: dockerimage
+    sourceid: GrafanaRelease
+    spec:
+      image: "grafana/agent"
+  checkDifference:
+    name: "Check if there is a difference in version"
+    kind: shell
+    spec:
+      command: sh -c '! grep -q {{ source `GrafanaRelease` }} bases/metrics/m/kustomization.yaml'
+
+targets:
+  updateKustomizationFileM:
+    name: "Update kustomization.yaml"
+    kind: yaml
+    spec:
+      file: "bases/metrics/m/kustomization.yaml"
+      key: "images[0].newTag"
+    sourceid: GrafanaRelease
+    transformers:
+      - addprefix: "'"
+      - addsuffix: "'"
+  updateKustomizationFileXL:
+    name: "Update kustomization.yaml"
+    kind: yaml
+    spec:
+      file: "bases/metrics/xl/kustomization.yaml"
+      key: "images[0].newTag"
+    sourceid: GrafanaRelease
+    transformers:
+      - addprefix: "'"
+      - addsuffix: "'"

--- a/updatecli/otel.yaml
+++ b/updatecli/otel.yaml
@@ -1,0 +1,49 @@
+# updatecli.yaml
+sources:
+  OtelRelease:
+    kind: "githubrelease"
+    spec:
+      owner: "open-telemetry"
+      repository: "opentelemetry-collector-contrib"
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+      # Added to take care of "v" prefix in version until the chart is updated to use the semver versioning (which doesn't have the "v" prefix)
+      versionFilter:
+        kind: "semver"
+        allowPrerelease: false
+    transformers:
+      - trimprefix: "v"
+
+conditions:
+  dockerimageExists:
+    name: "Docker Image exists"
+    kind: dockerimage
+    sourceid: OtelRelease
+    spec:
+      image: "otel/opentelemetry-collector-contrib"
+  checkDifference:
+    name: "Check if there is a difference in version"
+    kind: shell
+    spec:
+      command: sh -c '! grep -q {{ source `OtelRelease` }} bases/traces/daemonset/kustomization.yaml'
+
+targets:
+  updateKustomizationFileDaemonSet:
+    name: "Update kustomization.yaml"
+    kind: yaml
+    spec:
+      file: "bases/traces/daemonset/kustomization.yaml"
+      key: "images[0].newTag"
+    sourceid: OtelRelease
+    transformers:
+      - addprefix: "'"
+      - addsuffix: "'"
+  updateKustomizationFileDeployment:
+    name: "Update kustomization.yaml"
+    kind: yaml
+    spec:
+      file: "bases/traces/deployment/kustomization.yaml"
+      key: "images[0].newTag"
+    sourceid: OtelRelease
+    transformers:
+      - addprefix: "'"
+      - addsuffix: "'"


### PR DESCRIPTION
Introduce [update-cli](https://github.com/updatecli/updatecli) tool and configuration to create PR's to keep our dependencies current.

Sample run: https://github.com/hutchic-observe-meta/manifests/actions/runs/6177250098/job/16767990161
Sample PR: https://github.com/hutchic-observe-meta/manifests/pull/14