### PR TITLE
chore: don't open new PR's keep the already open PR up to date

### DIFF
--- a/.github/workflows/update-deps.yaml
+++ b/.github/workflows/update-deps.yaml
@@ -34,6 +34,5 @@ jobs:
           title: 'chore(deps): Update dependencies'
           body: |
             Updates dependencies using `updatecli`.
-          branch: automated-update-${{ github.run_number }}
           labels: automated-pr, update
           draft: false


### PR DESCRIPTION
We desire the [default behavirour](https://github.com/peter-evans/create-pull-request#action-behaviour) that keeps updating an existing branch