### PR TITLE
fix: extract k8s.cluster.uid through k8sattributes

### DIFF
--- a/bases/traces/base/clusterrole.yaml
+++ b/bases/traces/base/clusterrole.yaml
@@ -8,6 +8,7 @@ rules:
       - ""
     resources:
       - pods
+      - namespaces
     verbs:
       - get
       - list

--- a/bases/traces/base/config.yaml
+++ b/bases/traces/base/config.yaml
@@ -18,17 +18,15 @@ processors:
   probabilistic_sampler:
     hash_seed: ${OTEL_SAMPLER_HASH_SEED}
     sampling_percentage: ${OTEL_SAMPLER_PERCENTAGE}
-  resource:
-    attributes:
-      - key: k8s.cluster.uid
-        value: ${OBSERVE_CLUSTER}
-        action: insert
   k8sattributes:
     passthrough: false
+    filter:
+      node_from_env_var: FILTER_NODE_NAME
     extract:
       metadata:
         - k8s.pod.name
         - k8s.namespace.name
+        - k8s.cluster.uid
     pod_association:
       - sources:
           - from: resource_attribute
@@ -55,13 +53,13 @@ service:
   pipelines:
     traces:
       receivers: [otlp, zipkin]
-      processors: [resource, probabilistic_sampler, k8sattributes, memory_limiter, batch]
+      processors: [probabilistic_sampler, k8sattributes, memory_limiter, batch]
       exporters: [otlphttp, logging]
     metrics:
       receivers: [otlp]
-      processors: [resource, k8sattributes, memory_limiter, batch]
+      processors: [k8sattributes, memory_limiter, batch]
       exporters: [otlphttp, logging]
     logs:
       receivers: [otlp]
-      processors: [resource, k8sattributes, memory_limiter, batch]
+      processors: [k8sattributes, memory_limiter, batch]
       exporters: [otlphttp, logging]

--- a/bases/traces/daemonset/daemonset.yaml
+++ b/bases/traces/daemonset/daemonset.yaml
@@ -60,15 +60,10 @@ spec:
               cpu: 250m
               memory: 256Mi
           env:
-            - name: NODE_NAME
+            - name: FILTER_NODE_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            - name: OBSERVE_CLUSTER
-              valueFrom:
-                configMapKeyRef:
-                  name: cluster-info
-                  key: id
           envFrom:
             - configMapRef:
                 name: otel-collector-env

--- a/bases/traces/deployment/deployment.yaml
+++ b/bases/traces/deployment/deployment.yaml
@@ -61,16 +61,6 @@ spec:
             - name: zipkin
               containerPort: 9411
               protocol: TCP
-          env:
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: OBSERVE_CLUSTER
-              valueFrom:
-                configMapKeyRef:
-                  name: cluster-info
-                  key: id
           envFrom:
             - configMapRef:
                 name: otel-collector-env


### PR DESCRIPTION
k8sattributes processor now natively supports extracting `k8s.cluster.uid`, so we don't need to handle this through the resource processor anymore.

Helm PR: https://github.com/observeinc/helm-charts/pull/69