### PR TITLE
feat(traces): use memory limiter percentages

### DIFF
--- a/bases/traces/base/config.yaml
+++ b/bases/traces/base/config.yaml
@@ -34,10 +34,10 @@ processors:
           - from: connection
   batch:
   memory_limiter:
-    # 80% of maximum memory up to 2G
     limit_mib: ${OTEL_MEMORY_LIMITER_LIMIT_MIB}
-    # 25% of limit up to 2G
     spike_limit_mib: ${OTEL_MEMORY_LIMITER_SPIKE_LIMIT_MIB}
+    limit_percentage: ${OTEL_MEMORY_LIMITER_LIMIT_PERCENTAGE}
+    spike_limit_percentage: ${OTEL_MEMORY_LIMITER_SPIKE_LIMIT_PERCENTAGE}
     check_interval: "${OTEL_MEMORY_LIMITER_CHECK_INTERVAL}"
 receivers:
   zipkin:

--- a/bases/traces/base/kustomization.yaml
+++ b/bases/traces/base/kustomization.yaml
@@ -20,11 +20,8 @@ configMapGenerator:
       - OTEL_RETRY_ON_FAILURE=true
       - OTEL_SAMPLER_HASH_SEED=22
       - OTEL_SAMPLER_PERCENTAGE=100
-      # 80% of maximum memory up to 2G.
-      # Must be less than limit or gc will never run
-      - OTEL_MEMORY_LIMITER_LIMIT_MIB=192
-      # 25% of limit up to 2G
-      - OTEL_MEMORY_LIMITER_SPIKE_LIMIT_MIB=100
+      - OTEL_MEMORY_LIMITER_LIMIT_PERCENTAGE=80
+      - OTEL_MEMORY_LIMITER_SPIKE_LIMIT_PERCENTAGE=25
       - OTEL_MEMORY_LIMITER_CHECK_INTERVAL=5s
       # known to not work: https://github.com/open-telemetry/opentelemetry-collector/issues/4328
       - OTEL_LOG_LEVEL=info


### PR DESCRIPTION
The memory limiter in `otel-collector` originally only allowed specifying absolute values (`limit_mib` and `spike_limit_mib`). They've since introduced relative values. We will still respect configs where the previous values were explicitly set.