### PR TITLE
feat: cleanup deprecated references in kustomize

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ configmap:
 EXAMPLE_DIR=$(mktemp -d)
 
 cat <<EOF >$EXAMPLE_DIR/kustomization.yaml
-bases:
+resources:
   - github.com/observeinc/manifests//stack?ref=main
 
 configMapGenerator:

--- a/bases/events/l/kustomization.yaml
+++ b/bases/events/l/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-bases:
+resources:
   - ../m
 
 commonLabels:

--- a/bases/events/m/kustomization.yaml
+++ b/bases/events/m/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-bases:
+resources:
   - ../noop
 
 namePrefix: observe-
@@ -7,7 +7,7 @@ namePrefix: observe-
 commonLabels:
   observeinc.com/component: 'events'
 
-patchesJson6902:
+patches:
   - target:
       version: v1
       group: apps

--- a/bases/events/noop/kustomization.yaml
+++ b/bases/events/noop/kustomization.yaml
@@ -1,7 +1,4 @@
 ---
-commonLabels:
-  observeinc.com/component: 'events'
-
 resources:
   - clusterrole.yaml
   - clusterrolebinding.yaml
@@ -9,6 +6,9 @@ resources:
   - role.yaml
   - rolebinding.yaml
   - serviceaccount.yaml
+
+commonLabels:
+  observeinc.com/component: 'events'
 
 configMapGenerator:
   - name: kube-state-events-env

--- a/bases/events/xl/kustomization.yaml
+++ b/bases/events/xl/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-bases:
+resources:
   - ../m
 
 commonLabels:

--- a/bases/events/xs/kustomization.yaml
+++ b/bases/events/xs/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-bases:
+resources:
   - ../m
 
 commonLabels:

--- a/bases/logs/l/kustomization.yaml
+++ b/bases/logs/l/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-bases:
+resources:
   - ../m
 
 commonLabels:

--- a/bases/logs/m/kustomization.yaml
+++ b/bases/logs/m/kustomization.yaml
@@ -2,9 +2,12 @@
 resources:
   - daemonset.yaml
   - serviceaccount.yaml
+
 namePrefix: observe-
+
 commonLabels:
   observeinc.com/component: 'logs'
+
 configMapGenerator:
   - name: fluent-bit-config
     literals:
@@ -40,6 +43,7 @@ configMapGenerator:
       - OBSERVE_COLLECTOR_HOST=collect.observeinc.com
       - OBSERVE_COLLECTOR_PORT=443
       - OBSERVE_COLLECTOR_TLS=on
+
 images:
   - name: fluent/fluent-bit
     newTag: '2.2.0'

--- a/bases/logs/xl/kustomization.yaml
+++ b/bases/logs/xl/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-bases:
+resources:
   - ../m
 
 commonLabels:

--- a/bases/logs/xs/kustomization.yaml
+++ b/bases/logs/xs/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-bases:
+resources:
   - ../m
 
 commonLabels:

--- a/bases/metrics/base/kustomization.yaml
+++ b/bases/metrics/base/kustomization.yaml
@@ -1,11 +1,11 @@
 ---
-commonLabels:
-  observeinc.com/component: 'metrics'
-
 resources:
   - clusterrole.yaml
   - clusterrolebinding.yaml
   - serviceaccount.yaml
+
+commonLabels:
+  observeinc.com/component: 'metrics'
 
 configMapGenerator:
   - name: grafana-agent

--- a/bases/metrics/l/kustomization.yaml
+++ b/bases/metrics/l/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-bases:
+resources:
   - ../m
 
 commonLabels:

--- a/bases/metrics/m/kustomization.yaml
+++ b/bases/metrics/m/kustomization.yaml
@@ -1,11 +1,13 @@
 ---
-bases:
-  - ../base
 resources:
+  - ../base
   - deployment.yaml
+
 namePrefix: observe-
+
 commonLabels:
   observeinc.com/component: 'metrics'
+
 images:
   - name: grafana/agent
     newTag: 'v0.37.4'

--- a/bases/metrics/xl/kustomization.yaml
+++ b/bases/metrics/xl/kustomization.yaml
@@ -1,11 +1,13 @@
 ---
-bases:
-  - ../base
 resources:
+  - ../base
   - daemonset.yaml
+
 namePrefix: observe-
+
 commonLabels:
   observeinc.com/component: 'metrics'
+
 images:
   - name: grafana/agent
     newTag: 'v0.37.4'

--- a/bases/metrics/xs/kustomization.yaml
+++ b/bases/metrics/xs/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-bases:
+resources:
   - ../m
 
 commonLabels:

--- a/bases/traces/daemonset/kustomization.yaml
+++ b/bases/traces/daemonset/kustomization.yaml
@@ -1,11 +1,13 @@
 ---
-bases:
+resources:
   - ../base
+  - daemonset.yaml
+
 namePrefix: observe-
+
 commonLabels:
   observeinc.com/component: 'traces'
-resources:
-  - daemonset.yaml
+
 images:
   - name: otel/opentelemetry-collector-contrib
     newTag: '0.89.0'

--- a/bases/traces/deployment/kustomization.yaml
+++ b/bases/traces/deployment/kustomization.yaml
@@ -1,11 +1,13 @@
 ---
-bases:
-  - ../base
-namePrefix: observe-
 resources:
+  - ../base
   - deployment.yaml
+
+namePrefix: observe-
+
 commonLabels:
   observeinc.com/component: 'traces'
+
 images:
   - name: otel/opentelemetry-collector-contrib
     newTag: '0.89.0'

--- a/bases/traces/l/kustomization.yaml
+++ b/bases/traces/l/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-bases:
+resources:
   - ../deployment
 
 commonLabels:

--- a/bases/traces/m/kustomization.yaml
+++ b/bases/traces/m/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-bases:
+resources:
   - ../daemonset
 
 commonLabels:

--- a/bases/traces/xs/kustomization.yaml
+++ b/bases/traces/xs/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-bases:
+resources:
   - ../m
 
 commonLabels:

--- a/bases/winlogs/l/kustomization.yaml
+++ b/bases/winlogs/l/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-bases:
+resources:
   - ../m
 
 commonLabels:

--- a/bases/winlogs/m/kustomization.yaml
+++ b/bases/winlogs/m/kustomization.yaml
@@ -25,6 +25,7 @@ configMapGenerator:
       - OBSERVE_COLLECTOR_HOST=collect.observeinc.com
       - OBSERVE_COLLECTOR_PORT=443
       - OBSERVE_COLLECTOR_TLS=peer
+
 images:
   - name: fluent/fluentd
     newTag: 'v1.14.6-windows-20H2-1.0'

--- a/bases/winlogs/xl/kustomization.yaml
+++ b/bases/winlogs/xl/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-bases:
+resources:
   - ../m
 
 commonLabels:

--- a/bases/winlogs/xs/kustomization.yaml
+++ b/bases/winlogs/xs/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-bases:
+resources:
   - ../m
 
 commonLabels:

--- a/examples/crds/argo/kustomization.yaml
+++ b/examples/crds/argo/kustomization.yaml
@@ -1,12 +1,12 @@
 ---
-bases:
+resources:
   - ../../../bases/events/noop
 
 namespace: observe
 
 namePrefix: observe-argo-
 
-patchesJson6902:
+patches:
   - target:
       version: v1
       group: apps

--- a/examples/crds/openshift/kustomization.yaml
+++ b/examples/crds/openshift/kustomization.yaml
@@ -1,15 +1,13 @@
 ---
-bases:
+resources:
   - ../../../bases/events/noop
+  - constraints.yaml
 
 namespace: observe
 
 namePrefix: observe-openshift-
 
-resources:
-  - constraints.yaml
-
-patchesJson6902:
+patches:
   - target:
       version: v1
       group: apps

--- a/examples/openshift/kustomization.yaml
+++ b/examples/openshift/kustomization.yaml
@@ -1,8 +1,6 @@
 ---
-bases:
-  - ../../stack/m
-
 resources:
+  - ../../stack/m
   - constraints.yaml
 
 patchesStrategicMerge:

--- a/examples/pre-processing-logs/kustomization.yaml
+++ b/examples/pre-processing-logs/kustomization.yaml
@@ -1,4 +1,4 @@
-bases:
+resources:
   - ../../stack/xs
 
 configMapGenerator:

--- a/examples/traces/kustomization.yaml
+++ b/examples/traces/kustomization.yaml
@@ -1,7 +1,7 @@
 ---
 namespace: observe
 
-bases:
+resources:
   - ../../bases/traces/m
 
 configMapGenerator:

--- a/examples/xl-plus/kustomization.yaml
+++ b/examples/xl-plus/kustomization.yaml
@@ -1,4 +1,4 @@
-bases:
+resources:
   - github.com/observeinc/manifests/stack/xl?ref=main
 
 patchesStrategicMerge:

--- a/stack/kustomization.yaml
+++ b/stack/kustomization.yaml
@@ -1,3 +1,3 @@
 ---
-bases:
+resources:
   - m

--- a/stack/l/kustomization.yaml
+++ b/stack/l/kustomization.yaml
@@ -1,10 +1,8 @@
 ---
 namespace: observe
 
-bases:
+resources:
   - ../../bases/events/l
   - ../../bases/logs/l
   - ../../bases/metrics/l
-
-resources:
   - namespace.yaml

--- a/stack/m/kustomization.yaml
+++ b/stack/m/kustomization.yaml
@@ -1,10 +1,8 @@
 ---
 namespace: observe
 
-bases:
+resources:
   - ../../bases/events/m
   - ../../bases/logs/m
   - ../../bases/metrics/m
-
-resources:
   - namespace.yaml

--- a/stack/otel/kustomization.yaml
+++ b/stack/otel/kustomization.yaml
@@ -1,3 +1,3 @@
 ---
-bases:
+resources:
   - m

--- a/stack/otel/l/kustomization.yaml
+++ b/stack/otel/l/kustomization.yaml
@@ -1,6 +1,6 @@
 ---
 namespace: observe
 
-bases:
+resources:
   - ../../l
   - ../../../bases/traces/l

--- a/stack/otel/m/kustomization.yaml
+++ b/stack/otel/m/kustomization.yaml
@@ -1,6 +1,6 @@
 ---
 namespace: observe
 
-bases:
+resources:
   - ../../m
   - ../../../bases/traces/m

--- a/stack/otel/xl/kustomization.yaml
+++ b/stack/otel/xl/kustomization.yaml
@@ -1,6 +1,6 @@
 ---
 namespace: observe
 
-bases:
+resources:
   - ../../xl
   - ../../../bases/traces/l

--- a/stack/otel/xs/kustomization.yaml
+++ b/stack/otel/xs/kustomization.yaml
@@ -1,6 +1,6 @@
 ---
 namespace: observe
 
-bases:
+resources:
   - ../../xs
   - ../../../bases/traces/xs

--- a/stack/winlogs/l/kustomization.yaml
+++ b/stack/winlogs/l/kustomization.yaml
@@ -1,11 +1,9 @@
 ---
 namespace: observe
 
-bases:
+resources:
   - ../../../bases/events/l
   - ../../../bases/logs/l
   - ../../../bases/metrics/l
   - ../../../bases/winlogs/l
-
-resources:
   - namespace.yaml

--- a/stack/winlogs/m/kustomization.yaml
+++ b/stack/winlogs/m/kustomization.yaml
@@ -1,11 +1,9 @@
 ---
 namespace: observe
 
-bases:
+resources:
   - ../../../bases/events/m
   - ../../../bases/logs/m
   - ../../../bases/metrics/m
   - ../../../bases/winlogs/m
-
-resources:
   - namespace.yaml

--- a/stack/winlogs/xl/kustomization.yaml
+++ b/stack/winlogs/xl/kustomization.yaml
@@ -1,11 +1,9 @@
 ---
 namespace: observe
 
-bases:
+resources:
   - ../../../bases/events/xl
   - ../../../bases/logs/xl
   - ../../../bases/metrics/xl
   - ../../../bases/winlogs/xl
-
-resources:
   - namespace.yaml

--- a/stack/winlogs/xs/kustomization.yaml
+++ b/stack/winlogs/xs/kustomization.yaml
@@ -1,11 +1,9 @@
 ---
 namespace: observe
 
-bases:
+resources:
   - ../../../bases/events/xs
   - ../../../bases/logs/xs
   - ../../../bases/metrics/xs
   - ../../../bases/winlogs/xs
-
-resources:
   - namespace.yaml

--- a/stack/xl/kustomization.yaml
+++ b/stack/xl/kustomization.yaml
@@ -1,10 +1,8 @@
 ---
 namespace: observe
 
-bases:
+resources:
   - ../../bases/events/xl
   - ../../bases/logs/xl
   - ../../bases/metrics/xl
-
-resources:
   - namespace.yaml

--- a/stack/xs/kustomization.yaml
+++ b/stack/xs/kustomization.yaml
@@ -1,10 +1,8 @@
 ---
 namespace: observe
 
-bases:
+resources:
   - ../../bases/events/xs
   - ../../bases/logs/m
   - ../../bases/metrics/xs
-
-resources:
   - namespace.yaml


### PR DESCRIPTION
The kustomize version packaged since 1.19 has full support for refering to `bases` as `resources`. More recent versions have started to raise a warning:

```
Warning: 'patchesJson6902' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
Warning: 'bases' is deprecated. Please use 'resources' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
```