### PR TITLE
feat(metrics): per job scrape interval, tweak defaults.

### DIFF
--- a/bases/metrics/base/agent.yaml
+++ b/bases/metrics/base/agent.yaml
@@ -32,6 +32,7 @@ metrics:
       scrape_configs:
         - job_name: "integrations/kubernetes/pods"
           bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          scrape_interval: ${PROM_SCRAPE_POD_INTERVAL}
           sample_limit: ${PROM_SCRAPE_SAMPLE_LIMIT}
           body_size_limit: ${PROM_SCRAPE_BODY_SIZE_LIMIT}
           kubernetes_sd_configs:
@@ -133,6 +134,7 @@ metrics:
 
         - job_name: "integrations/kubernetes/kubelet"
           bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          scrape_interval: ${PROM_SCRAPE_KUBELET_INTERVAL}
           sample_limit: ${PROM_SCRAPE_SAMPLE_LIMIT}
           body_size_limit: ${PROM_SCRAPE_BODY_SIZE_LIMIT}
           kubernetes_sd_configs:
@@ -163,6 +165,7 @@ metrics:
 
         - job_name: "integrations/kubernetes/resource"
           bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          scrape_interval: ${PROM_SCRAPE_RESOURCE_INTERVAL}
           sample_limit: ${PROM_SCRAPE_SAMPLE_LIMIT}
           body_size_limit: ${PROM_SCRAPE_BODY_SIZE_LIMIT}
           kubernetes_sd_configs:
@@ -193,6 +196,7 @@ metrics:
 
         - job_name: "integrations/kubernetes/cadvisor"
           bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          scrape_interval: ${PROM_SCRAPE_CADVISOR_INTERVAL}
           sample_limit: ${PROM_SCRAPE_SAMPLE_LIMIT}
           body_size_limit: ${PROM_SCRAPE_BODY_SIZE_LIMIT}
           kubernetes_sd_configs:

--- a/bases/metrics/base/kustomization.yaml
+++ b/bases/metrics/base/kustomization.yaml
@@ -32,6 +32,7 @@ configMapGenerator:
       - PROM_SCRAPE_TIMEOUT=10s
       - PROM_SCRAPE_BODY_SIZE_LIMIT=50MB
       - PROM_SCRAPE_CADVISOR_ACTION=keep
+      - PROM_SCRAPE_CADVISOR_INTERVAL=
       # The following metrics are exported with 0 values in default cadvisor installs. See:
       # - https://github.com/kubernetes/kubernetes/issues/60279
       # - https://github.com/google/cadvisor/issues/1672
@@ -40,15 +41,18 @@ configMapGenerator:
       # The following regex matches the default Kubernetes board metrics:
       # - PROM_SCRAPE_CADVISOR_METRIC_KEEP_REGEX=container_(cpu_cfs_.*|spec_.*|cpu_cores|cpu_usage_seconds_total|memory_working_set_bytes|memory_usage_bytes|network_transmit_.*|network_receive_.*|fs_writes_total|fs_reads_total|file_descriptors)|machine_(cpu_cores|memory_bytes)
       - PROM_SCRAPE_KUBELET_ACTION=drop
+      - PROM_SCRAPE_KUBELET_INTERVAL=
       - PROM_SCRAPE_KUBELET_METRIC_DROP_REGEX=
       - PROM_SCRAPE_KUBELET_METRIC_KEEP_REGEX=(.*)
       - PROM_SCRAPE_POD_ACTION=keep
+      - PROM_SCRAPE_POD_INTERVAL=60s
       - PROM_SCRAPE_POD_NAMESPACE_DROP_REGEX=(.*istio.*|.*ingress.*|kube-system)
       - PROM_SCRAPE_POD_NAMESPACE_KEEP_REGEX=(.*)
       - PROM_SCRAPE_POD_PORT_KEEP_REGEX=.*metrics
       - PROM_SCRAPE_POD_METRIC_DROP_REGEX=.*bucket
       - PROM_SCRAPE_POD_METRIC_KEEP_REGEX=(.*)
       - PROM_SCRAPE_RESOURCE_ACTION=keep
+      - PROM_SCRAPE_RESOURCE_INTERVAL=
       - PROM_SCRAPE_RESOURCE_METRIC_DROP_REGEX=
       - PROM_SCRAPE_RESOURCE_METRIC_KEEP_REGEX=(.*)
       - PROM_SCRAPE_SAMPLE_LIMIT=100000


### PR DESCRIPTION
Introduce a per-job scrape interval override and increase pod scrape interval to 60s, since it is a significant source of burstiness when collecting metrics.