### PR TITLE
Truncate to limit record size with best effort

### DIFF
--- a/bases/traces/base/config.yaml
+++ b/bases/traces/base/config.yaml
@@ -39,15 +39,13 @@ processors:
     limit_percentage: ${OTEL_MEMORY_LIMITER_LIMIT_PERCENTAGE}
     spike_limit_percentage: ${OTEL_MEMORY_LIMITER_SPIKE_LIMIT_PERCENTAGE}
     check_interval: "${OTEL_MEMORY_LIMITER_CHECK_INTERVAL}"
-
-  # truncate to ensure the msg is under the limit accepted by the collector
+  # truncate individual strings under certain keys to try to avoid hitting the record size limit at observe collector
   transform/truncate:
     trace_statements:
       - context: span
         statements:
           - truncate_all(attributes, 10240)
           - truncate_all(resource.attributes, 10240)
-    
 receivers:
   zipkin:
   otlp:
@@ -62,7 +60,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp, zipkin]
-      processors: [probabilistic_sampler, k8sattributes, memory_limiter, transform/truncate, batch]
+      processors: [probabilistic_sampler, transform/truncate, k8sattributes, memory_limiter, batch]
       exporters: [otlphttp, logging]
     metrics:
       receivers: [otlp]

--- a/bases/traces/base/config.yaml
+++ b/bases/traces/base/config.yaml
@@ -33,6 +33,7 @@ processors:
       - sources:
           - from: connection
   batch:
+    send_batch_max_size: ${OTEL_SEND_BATCH_MAX_SIZE}
   memory_limiter:
     limit_mib: ${OTEL_MEMORY_LIMITER_LIMIT_MIB}
     spike_limit_mib: ${OTEL_MEMORY_LIMITER_SPIKE_LIMIT_MIB}
@@ -44,8 +45,12 @@ processors:
     trace_statements:
       - context: span
         statements:
-          - truncate_all(attributes, 10240)
-          - truncate_all(resource.attributes, 10240)
+          - truncate_all(attributes, ${OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT})
+          - truncate_all(resource.attributes, ${OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT})
+      - context: spanevent
+        statements:
+          - truncate_all(attributes, ${OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT})
+          - truncate_all(resource.attributes, ${OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT})
 receivers:
   zipkin:
   otlp:

--- a/bases/traces/base/config.yaml
+++ b/bases/traces/base/config.yaml
@@ -39,6 +39,15 @@ processors:
     limit_percentage: ${OTEL_MEMORY_LIMITER_LIMIT_PERCENTAGE}
     spike_limit_percentage: ${OTEL_MEMORY_LIMITER_SPIKE_LIMIT_PERCENTAGE}
     check_interval: "${OTEL_MEMORY_LIMITER_CHECK_INTERVAL}"
+
+  # truncate to ensure the msg is under the limit accepted by the collector
+  transform/truncate:
+    trace_statements:
+      - context: span
+        statements:
+          - truncate_all(attributes, 10240)
+          - truncate_all(resource.attributes, 10240)
+    
 receivers:
   zipkin:
   otlp:
@@ -53,7 +62,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp, zipkin]
-      processors: [probabilistic_sampler, k8sattributes, memory_limiter, batch]
+      processors: [probabilistic_sampler, k8sattributes, memory_limiter, transform/truncate, batch]
       exporters: [otlphttp, logging]
     metrics:
       receivers: [otlp]

--- a/bases/traces/base/kustomization.yaml
+++ b/bases/traces/base/kustomization.yaml
@@ -26,6 +26,8 @@ configMapGenerator:
       - OTEL_MEMORY_LIMITER_CHECK_INTERVAL=5s
       # known to not work: https://github.com/open-telemetry/opentelemetry-collector/issues/4328
       - OTEL_LOG_LEVEL=info
+      - OTEL_SEND_BATCH_MAX_SIZE=0
+      - OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT=10240
   - name: otel-collector
     literals:
       - extra.yaml=


### PR DESCRIPTION
Observe collection API has a limit of 4MB per observation event. We ideally don't want the data to be transmitted to the API just to get rejected. This is to truncate the values inside attributes and resource.attributes of a span in the hope that the entire observation will not exceed the limit from the API. 

One might want to drop the data at the OTel collector. But that would cause the entire record to be lost. 

Testing done:
- verified this in testbox. Specifically, used telemetrygen to generate a 6MB Span (basically a binary blob was inserted under the `attrbutes.load-0` key. Otel collector reports HTTP 413 without the fix. With the fix, it truncates the data and the Span message was seen in testbox UI.  