### PR TITLE
fix(logs): add FB_IGNORE_OLDER

### DIFF
--- a/bases/logs/m/fluent-bit.conf
+++ b/bases/logs/m/fluent-bit.conf
@@ -24,6 +24,7 @@
     DB                  /var/log/flb_kube_${NAMESPACE}.db
     Skip_Long_Lines     On
     Read_From_Head      ${FB_READ_FROM_HEAD}
+    Ignore_Older        ${FB_IGNORE_OLDER}
     Mem_Buf_Limit       ${FB_MEM_BUF_LIMIT}
     Buffer_Chunk_Size   ${FB_BUFFER_CHUNK_SIZE}
     Buffer_Max_Size     ${FB_BUFFER_MAX_SIZE}
@@ -41,6 +42,7 @@
     DB                  /var/log/flb_node_${NAMESPACE}.db
     Skip_Long_Lines     On
     Read_From_Head      ${FB_READ_FROM_HEAD}
+    Ignore_Older        ${FB_IGNORE_OLDER}
     Mem_Buf_Limit       ${FB_MEM_BUF_LIMIT}
     Buffer_Chunk_Size   ${FB_BUFFER_CHUNK_SIZE}
     Buffer_Max_Size     ${FB_BUFFER_MAX_SIZE}

--- a/bases/logs/m/kustomization.yaml
+++ b/bases/logs/m/kustomization.yaml
@@ -25,6 +25,7 @@ configMapGenerator:
       - FB_HC_ERRORS_COUNT=5
       - FB_HC_RETRY_FAILURE_COUNT=5
       - FB_HC_PERIOD=10
+      - FB_IGNORE_OLDER=2d
       - FB_LOG_LEVEL=warning
       - FB_MEM_BUF_LIMIT=10MB
       - FB_NODE_LOG_INCLUDE_PATH=/var/log/kube-apiserver-audit.log


### PR DESCRIPTION
Ignore log files older than two days by default. This is configurable, but will avoid surprises when installing manifest for first time.