### PR TITLE
Increase attribute value length limit for spans

### DIFF
--- a/bases/traces/base/kustomization.yaml
+++ b/bases/traces/base/kustomization.yaml
@@ -27,7 +27,7 @@ configMapGenerator:
       # known to not work: https://github.com/open-telemetry/opentelemetry-collector/issues/4328
       - OTEL_LOG_LEVEL=info
       - OTEL_SEND_BATCH_MAX_SIZE=0
-      - OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT=10240
+      - OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT=1048576
   - name: otel-collector
     literals:
       - extra.yaml=


### PR DESCRIPTION
Increase it to 1MB per OB-27856. 1MB seems too liberal, but this is mainly to unblock some existing usage that depends on long attribute values. We will discuss what a better value to set long term separately.