### PR TITLE
fix(metrics)!: Stop collecting container_fs_xxx metrics to reduce a to reduce a data volume and make the data collection of some cadvisor metrics opted-in

### DIFF
--- a/bases/metrics/base/kustomization.yaml
+++ b/bases/metrics/base/kustomization.yaml
@@ -37,7 +37,7 @@ configMapGenerator:
       # - https://github.com/kubernetes/kubernetes/issues/60279
       # - https://github.com/google/cadvisor/issues/1672
       - PROM_SCRAPE_CADVISOR_METRIC_DROP_REGEX=container_(network_tcp_usage_total|network_udp_usage_total|tasks_state|cpu_load_average_10s)
-      - PROM_SCRAPE_CADVISOR_METRIC_KEEP_REGEX=container_(cpu_.*|spec_.*|memory_.*|network_.*|fs_.*|file_descriptors)|machine_(cpu_cores|memory_bytes)
+      - PROM_SCRAPE_CADVISOR_METRIC_KEEP_REGEX=container_(cpu_.*|spec_.*|memory_.*|network_.*|file_descriptors)|machine_(cpu_cores|memory_bytes)
       # The following regex matches the default Kubernetes board metrics:
       # - PROM_SCRAPE_CADVISOR_METRIC_KEEP_REGEX=container_(cpu_cfs_.*|spec_.*|cpu_cores|cpu_usage_seconds_total|memory_working_set_bytes|memory_usage_bytes|network_transmit_.*|network_receive_.*|fs_writes_total|fs_reads_total|file_descriptors)|machine_(cpu_cores|memory_bytes)
       - PROM_SCRAPE_KUBELET_ACTION=drop


### PR DESCRIPTION
BREAKING CHANGE: PROM_SCRAPE_POD_ACTION was previously set to keep but is changed to drop to reduce a data volume and make the data collection of pod metrics opted-in. https://docs.observeinc.com/en/latest/content/integrations/kubernetes/collecting_pod_metrics_cadvisor_metrics.html