### PR TITLE
fix(metrics): only scrape init containers if port set

### DIFF
--- a/bases/metrics/base/agent.yaml
+++ b/bases/metrics/base/agent.yaml
@@ -59,6 +59,9 @@ metrics:
             - action: 'drop'
               regex: 'Succeeded|Failed'
               source_labels: ['__meta_kubernetes_pod_phase']
+            - action: 'drop'
+              regex: 'true;'
+              source_labels: ['__meta_kubernetes_pod_container_init', '__meta_kubernetes_pod_container_port_name']
             # Drop anything annotated with 'prometheus.io.scrape=false'.
             - action: 'drop'
               regex: 'false'


### PR DESCRIPTION
This commit fixes a bug whereby init containers would result in duplicate metrics. The following pod template would exercise this bug:

```
template:
  metadata:
    labels:
      app: hello-world
    annotations:
      prometheus.io/scrape: "true"
      prometheus.io/path: "/metrics"
      prometheus.io/port: "9001"
  spec:
    initContainers:
    - name: init
      image: busybox
      command: ['sh', '-c', 'echo "hello world"']
    containers:
    - name: main
      image: quay.io/prometheuscommunity/avalanche:main
```

The `prometheus.io/port` creates targets for both containers in the resulting pod. We should assume any such annotations are not applicable to init containers. If scraping from an init container is desired, the manifest should be modified to use port names instead:

```
template:
  metadata:
    labels:
      app: hello-world
  spec:
    initContainers:
    - name: init
      image: custom-image-with-metrics
      ports:
        - containerPort: 9090
          name: metrics
    containers:
    - name: main
      image: quay.io/prometheuscommunity/avalanche:main
      ports:
        - containerPort: 9090
          name: metrics
```