### PR TITLE
feat(traces): allow OBSERVE_CLUSTER override

### DIFF
--- a/bases/traces/base/config.yaml
+++ b/bases/traces/base/config.yaml
@@ -44,6 +44,9 @@ processors:
         action: insert
       - key: fallback.service.version
         action: delete
+      - key: k8s.cluster.uid
+        value: ${OBSERVE_CLUSTER}
+        action: ${OTEL_OBSERVE_CLUSTER_ACTION}
   batch:
     send_batch_max_size: ${OTEL_SEND_BATCH_MAX_SIZE}
   memory_limiter:

--- a/bases/traces/base/kustomization.yaml
+++ b/bases/traces/base/kustomization.yaml
@@ -29,6 +29,8 @@ configMapGenerator:
       - OTEL_SEND_BATCH_MAX_SIZE=0
       - OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT=1048576
       - OTEL_SERVICE_VERSION_LABEL_KEY_REGEX=(pod-template-hash|controller-revision-hash|job-name)
+      # must be modified to `upsert` in order to override default cluster UID
+      - OTEL_OBSERVE_CLUSTER_ACTION=insert
   - name: otel-collector
     literals:
       - extra.yaml=


### PR DESCRIPTION
Reintroduce the ability to use an `OBSERVE_CLUSTER` environment variable to override the existing `k8s.cluster.uid` resource attribute. This can be useful when migrating clusters.

In order for this override to take effect, the
`OTEL_OBSERVE_CLUSTER_ACTION` variable must be set to `upsert`. This is a somewhat clumsy API but it works around limitations in the ability to compose OTEL configuration in Kustomize.