### PR TITLE
fix(traces): add resource processor to metrics, logs

### DIFF
--- a/bases/traces/base/config.yaml
+++ b/bases/traces/base/config.yaml
@@ -84,9 +84,9 @@ service:
       exporters: [otlphttp, logging]
     metrics:
       receivers: [otlp]
-      processors: [k8sattributes, memory_limiter, batch]
+      processors: [k8sattributes, resource, memory_limiter, batch]
       exporters: [otlphttp, logging]
     logs:
       receivers: [otlp]
-      processors: [k8sattributes, memory_limiter, batch]
+      processors: [k8sattributes, resource, memory_limiter, batch]
       exporters: [otlphttp, logging]


### PR DESCRIPTION
This was inadvertently omitted in
https://github.com/observeinc/manifests/pull/167. We should apply the same pipeline to all signals.