### PR TITLE
fix(traces): replace deprecated logging exporter

### DIFF
--- a/bases/traces/base/config.yaml
+++ b/bases/traces/base/config.yaml
@@ -1,7 +1,6 @@
 ---
 exporters:
-  logging:
-    loglevel: "${OTEL_LOG_LEVEL}"
+  debug: {}
   otlphttp:
     endpoint: "${OBSERVE_COLLECTOR_SCHEME}://${OBSERVE_CUSTOMER}.${OBSERVE_COLLECTOR_HOST}:${OBSERVE_COLLECTOR_PORT}/${OBSERVE_COLLECTOR_OTEL_VERSION}/otel"
     headers:
@@ -75,18 +74,18 @@ receivers:
 service:
   telemetry:
     logs:
-      level: "${OTEL_LOG_LEVEL}"
+      level: "info"
   extensions: [health_check, zpages]
   pipelines:
     traces:
       receivers: [otlp, zipkin]
       processors: [probabilistic_sampler, transform/truncate, k8sattributes, resource, memory_limiter, batch]
-      exporters: [otlphttp, logging]
+      exporters: [otlphttp, debug]
     metrics:
       receivers: [otlp]
       processors: [k8sattributes, resource, memory_limiter, batch]
-      exporters: [otlphttp, logging]
+      exporters: [otlphttp, debug]
     logs:
       receivers: [otlp]
       processors: [k8sattributes, resource, memory_limiter, batch]
-      exporters: [otlphttp, logging]
+      exporters: [otlphttp, debug]

--- a/bases/traces/base/kustomization.yaml
+++ b/bases/traces/base/kustomization.yaml
@@ -25,7 +25,6 @@ configMapGenerator:
       - OTEL_MEMORY_LIMITER_SPIKE_LIMIT_PERCENTAGE=25
       - OTEL_MEMORY_LIMITER_CHECK_INTERVAL=5s
       # known to not work: https://github.com/open-telemetry/opentelemetry-collector/issues/4328
-      - OTEL_LOG_LEVEL=info
       - OTEL_SEND_BATCH_MAX_SIZE=0
       - OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT=1048576
       - OTEL_SERVICE_VERSION_LABEL_KEY_REGEX=(pod-template-hash|controller-revision-hash|job-name)

--- a/bases/traces/daemonset/kustomization.yaml
+++ b/bases/traces/daemonset/kustomization.yaml
@@ -7,4 +7,4 @@ commonLabels:
   observeinc.com/component: 'traces'
 images:
   - name: otel/opentelemetry-collector-contrib
-    newTag: '0.112.0'
+    newTag: '0.101.0'

--- a/bases/traces/deployment/kustomization.yaml
+++ b/bases/traces/deployment/kustomization.yaml
@@ -7,4 +7,4 @@ commonLabels:
   observeinc.com/component: 'traces'
 images:
   - name: otel/opentelemetry-collector-contrib
-    newTag: '0.112.0'
+    newTag: '0.101.0'


### PR DESCRIPTION
Logging exporter was removed as of https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.111.0
Debug exporter is the replacement.